### PR TITLE
fix: support TUI for windows terminals (PowerShell and CMD)

### DIFF
--- a/spec/tui/events/mouse_event_spec.cr
+++ b/spec/tui/events/mouse_event_spec.cr
@@ -196,6 +196,11 @@ describe "Panel scroll events" do
 end
 
 describe "SplitContainer drag events" do
+  before_each do
+    Tui::Widget.mouse_capture = nil
+    Tui::Widget.handling_capture = false
+  end
+
   it "starts dragging on press over splitter" do
     split = Tui::SplitContainer.new(direction: Tui::SplitContainer::Direction::Horizontal)
     split.rect = Tui::Rect.new(0, 0, 40, 20)

--- a/spec/tui/markdown/parser_spec.cr
+++ b/spec/tui/markdown/parser_spec.cr
@@ -94,7 +94,16 @@ describe Tui::Markdown::Parser do
 
     it "parses bold with __" do
       doc = Tui::Markdown.parse("This is __bold__ text")
+      doc[0].elements.size.should eq 3
       doc[0].elements[1].type.should eq Tui::Markdown::InlineType::Bold
+      doc[0].elements[1].text.should eq "bold"
+    end
+
+    it "does not treat underscores inside an identifier as bold" do
+      doc = Tui::Markdown.parse("See variable_names_with_underscores here")
+      doc[0].elements.size.should eq 1
+      doc[0].elements[0].type.should eq Tui::Markdown::InlineType::Text
+      doc[0].elements[0].text.should eq "See variable_names_with_underscores here"
     end
 
     it "parses italic with *" do
@@ -106,6 +115,14 @@ describe Tui::Markdown::Parser do
     it "parses italic with _" do
       doc = Tui::Markdown.parse("This is _italic_ text")
       doc[0].elements[1].type.should eq Tui::Markdown::InlineType::Italic
+      doc[0].elements[1].text.should eq "italic"
+    end
+
+    it "does not treat underscores inside an identifier as italic" do
+      doc = Tui::Markdown.parse("See variable_names_with_underscores here")
+      doc[0].elements.size.should eq 1
+      doc[0].elements[0].type.should eq Tui::Markdown::InlineType::Text
+      doc[0].elements[0].text.should eq "See variable_names_with_underscores here"
     end
 
     it "parses bold+italic with ***" do

--- a/src/tui/markdown/parser.cr
+++ b/src/tui/markdown/parser.cr
@@ -437,7 +437,8 @@ module Tui
           remaining = text[pos..]
 
           # Bold+Italic: ***text*** only
-          # Note: ___ style disabled to protect variable_names_with_underscores
+          # Note: ___ style not supported (only *** is), consistent with Bold/Italic
+          # below which support ** and __ / * and _ respectively
           if m = remaining.match(/^\*\*\*(.+?)\*\*\*/)
             flush_text(elements, current_text)
             current_text = ""
@@ -457,14 +458,37 @@ module Tui
           end
 
           # Italic: *text* only
-          # Note: _ style disabled to protect variable_names_with_underscores
-          # Using only asterisks for emphasis avoids breaking code identifiers
           if m = remaining.match(/^\*([^*]+?)\*/)
             flush_text(elements, current_text)
             current_text = ""
             elements << InlineElement.new(InlineType::Italic, m[1])
             pos += m[0].size
             next
+          end
+
+          # Bold: __text__
+          # Only at word boundaries, so identifiers like variable_names_with_underscores
+          # are left untouched (an opening delimiter can't be preceded by a word char).
+          if remaining.starts_with?("__") && !intraword_boundary?(text, pos)
+            if m = remaining.match(/^__(.+?)__(?!\w)/)
+              flush_text(elements, current_text)
+              current_text = ""
+              elements << InlineElement.new(InlineType::Bold, m[1])
+              pos += m[0].size
+              next
+            end
+          end
+
+          # Italic: _text_
+          # Same word-boundary guard as __ above.
+          if remaining.starts_with?("_") && !remaining.starts_with?("__") && !intraword_boundary?(text, pos)
+            if m = remaining.match(/^_([^_]+?)_(?!\w)/)
+              flush_text(elements, current_text)
+              current_text = ""
+              elements << InlineElement.new(InlineType::Italic, m[1])
+              pos += m[0].size
+              next
+            end
           end
 
           # Strikethrough: ~~text~~
@@ -514,6 +538,18 @@ module Tui
       private def flush_text(elements : Array(InlineElement), text : String) : Nil
         return if text.empty?
         elements << InlineElement.new(InlineType::Text, text)
+      end
+
+      # True if the underscore delimiter at `pos` sits immediately after a word
+      # character, i.e. it's part of an identifier (variable_names_with_underscores)
+      # rather than a standalone emphasis delimiter.
+      private def intraword_boundary?(text : String, pos : Int32) : Bool
+        return false if pos == 0
+        word_char?(text[pos - 1])
+      end
+
+      private def word_char?(char : Char) : Bool
+        char.alphanumeric? || char == '_'
       end
     end
 

--- a/src/tui/markdown/view.cr
+++ b/src/tui/markdown/view.cr
@@ -1133,7 +1133,7 @@ module Tui
                 end
 
                 # Apply cursor highlight (inverted colors)
-                if @show_cursor && line_idx == @cursor_line && char_idx == @cursor_col
+                if @show_cursor && focused? && line_idx == @cursor_line && char_idx == @cursor_col
                   final_style = Style.new(fg: Color.black, bg: Color.palette(250), attrs: final_style.attrs)
                 end
 
@@ -1157,7 +1157,7 @@ module Tui
         end
 
         # Draw cursor at end of line if cursor position is past all characters
-        if @show_cursor && line_idx == @cursor_line && char_idx == @cursor_col
+        if @show_cursor && focused? && line_idx == @cursor_line && char_idx == @cursor_col
           cursor_x_pos = virtual_col - @scroll_x
           if cursor_x_pos >= 0 && cursor_x_pos < content_width
             cursor_style = Style.new(fg: Color.black, bg: Color.palette(250))

--- a/src/tui/terminal/terminal.cr
+++ b/src/tui/terminal/terminal.cr
@@ -90,11 +90,22 @@ module Tui::Terminal
 
   # Get terminal size
   def size : {Int32, Int32}
-    # Try ioctl first
-    ws = uninitialized LibC::Winsize
-    if LibC.ioctl(STDOUT.fd, LibC::TIOCGWINSZ, pointerof(ws)) == 0
-      return {ws.ws_col.to_i32, ws.ws_row.to_i32}
-    end
+    {% if flag?(:win32) %}
+      # Try the Windows console API first
+      info = uninitialized LibC::CONSOLE_SCREEN_BUFFER_INFO
+      handle = LibC.GetStdHandle(LibC::STD_OUTPUT_HANDLE)
+      if handle != LibC::INVALID_HANDLE_VALUE && LibC.GetConsoleScreenBufferInfo(handle, pointerof(info)) != 0
+        cols = (info.srWindow.right - info.srWindow.left + 1).to_i32
+        rows = (info.srWindow.bottom - info.srWindow.top + 1).to_i32
+        return {cols, rows} if cols > 0 && rows > 0
+      end
+    {% else %}
+      # Try ioctl first
+      ws = uninitialized LibC::Winsize
+      if LibC.ioctl(STDOUT.fd, LibC::TIOCGWINSZ, pointerof(ws)) == 0
+        return {ws.ws_col.to_i32, ws.ws_row.to_i32}
+      end
+    {% end %}
 
     # Fallback to environment variables
     cols = ENV["COLUMNS"]?.try(&.to_i32?) || 80
@@ -143,41 +154,107 @@ module Tui::Terminal
   end
 
   private def setup_signals : Nil
-    # Handle SIGWINCH for terminal resize - notify via channel
-    Signal::WINCH.trap do
-      select
-      when @@resize_channel.send(nil)
-      else
-        # Channel full, resize already pending
+    {% if flag?(:win32) %}
+      # Windows has no SIGWINCH equivalent; poll the console size instead.
+      start_resize_poller
+
+      # Signal::INT/TERM traps raise NotImplementedError on win32.
+      # Process.on_terminate is the portable replacement (backed by
+      # SetConsoleCtrlHandler) and covers both cases below.
+      Process.on_terminate do |reason|
+        if reason.interrupted?
+          @@sigint_pending = true
+        else
+          shutdown
+          exit(143)
+        end
+      end
+    {% else %}
+      # Handle SIGWINCH for terminal resize - notify via channel
+      Signal::WINCH.trap do
+        select
+        when @@resize_channel.send(nil)
+        else
+          # Channel full, resize already pending
+        end
+      end
+
+      # Handle SIGINT and SIGTERM for clean shutdown
+      Signal::INT.trap do
+        @@sigint_pending = true
+      end
+
+      Signal::TERM.trap do
+        shutdown
+        exit(143)
+      end
+    {% end %}
+  end
+
+  {% if flag?(:win32) %}
+    # Windows exposes no console-resize event; poll GetConsoleScreenBufferInfo
+    # periodically and feed changes into the same resize_channel the Unix
+    # WINCH trap uses.
+    private def start_resize_poller : Nil
+      spawn do
+        last_size = size
+        loop do
+          sleep 250.milliseconds
+          current = size
+          next if current == last_size
+          last_size = current
+          select
+          when @@resize_channel.send(nil)
+          else
+            # Channel full, resize already pending
+          end
+        end
       end
     end
-
-    # Handle SIGINT and SIGTERM for clean shutdown
-    Signal::INT.trap do
-      @@sigint_pending = true
-    end
-
-    Signal::TERM.trap do
-      shutdown
-      exit(143)
-    end
-  end
-end
-
-# C library bindings for terminal size
-lib LibC
-  struct Winsize
-    ws_row : UInt16
-    ws_col : UInt16
-    ws_xpixel : UInt16
-    ws_ypixel : UInt16
-  end
-
-  {% if flag?(:darwin) %}
-    TIOCGWINSZ = 0x40087468_u64
-  {% else %}
-    TIOCGWINSZ = 0x5413_u64
   {% end %}
-
-  fun ioctl(fd : Int32, request : UInt64, ...) : Int32
 end
+
+{% if flag?(:win32) %}
+  # C library bindings for terminal size (Windows console API)
+  lib LibC
+    struct COORD
+      x : Int16
+      y : Int16
+    end
+
+    struct SMALL_RECT
+      left : Int16
+      top : Int16
+      right : Int16
+      bottom : Int16
+    end
+
+    struct CONSOLE_SCREEN_BUFFER_INFO
+      dwSize : COORD
+      dwCursorPosition : COORD
+      wAttributes : UInt16
+      srWindow : SMALL_RECT
+      dwMaximumWindowSize : COORD
+    end
+
+    fun GetConsoleScreenBufferInfo(hConsoleOutput : HANDLE, lpConsoleScreenBufferInfo : CONSOLE_SCREEN_BUFFER_INFO*) : BOOL
+  end
+{% else %}
+  # C library bindings for terminal size
+  lib LibC
+    struct Winsize
+      ws_row : UInt16
+      ws_col : UInt16
+      ws_xpixel : UInt16
+      ws_ypixel : UInt16
+    end
+
+    {% if flag?(:darwin) %}
+      TIOCGWINSZ = 0x40087468_u64
+    {% else %}
+      TIOCGWINSZ = 0x5413_u64
+    {% end %}
+
+    fun ioctl(fd : Int32, request : UInt64, ...) : Int32
+  end
+{% end %}

--- a/src/tui/unicode.cr
+++ b/src/tui/unicode.cr
@@ -2,10 +2,13 @@
 # Based on wcwidth (https://github.com/jquast/wcwidth) and Unicode Standard Annex #11
 # Tables from Unicode 15.0
 require "string/grapheme"
-lib LibC
-  alias WCharT = Int32
-  fun wcwidth(c : WCharT) : Int32
-end
+
+{% unless flag?(:win32) %}
+  lib LibC
+    alias WCharT = Int32
+    fun wcwidth(c : WCharT) : Int32
+  end
+{% end %}
 
 module Tui
   module Unicode
@@ -459,6 +462,16 @@ module Tui
       {0x2600, 0x27BF},   # Misc symbols + Dingbats
     ]
 
+    # Windows' C runtime has no wcwidth(); report "unknown" (-1) so
+    # char_width falls back to the Unicode range tables below.
+    private def self.wcwidth(codepoint : Int32) : Int32
+      {% if flag?(:win32) %}
+        -1
+      {% else %}
+        LibC.wcwidth(codepoint)
+      {% end %}
+    end
+
     # Binary search in sorted ranges
     private def self.in_ranges?(codepoint : Int32, ranges : Array(Tuple(Int32, Int32))) : Bool
       low = 0
@@ -491,7 +504,7 @@ module Tui
       # Zero-width characters (combining marks, format chars, etc.)
       return 0 if in_ranges?(codepoint, ZERO_WIDTH)
 
-      sys_width = LibC.wcwidth(codepoint)
+      sys_width = wcwidth(codepoint)
       if sys_width >= 0
         # Override when terminals render emoji/symbols as wide but wcwidth reports 1.
         if sys_width == 1 && (in_ranges?(codepoint, WIDE_CHARS) || (ambiguous_wide? && in_ranges?(codepoint, EMOJI_WIDE)))


### PR DESCRIPTION
## Description

This PR allows to support TUIs on different Windows terminals (like Windows Terminal, cmd.exe...). In addition, Markdown text styles _(bold, italic, underline...)_ are also supported.

These changes are assisted thanks to Claude Sonnet model.