### PR TITLE
Support terminal resize for FreeBSD

### DIFF
--- a/src/tui/terminal/terminal.cr
+++ b/src/tui/terminal/terminal.cr
@@ -173,7 +173,7 @@ lib LibC
     ws_ypixel : UInt16
   end
 
-  {% if flag?(:darwin) %}
+  {% if flag?(:darwin) || flag?(:freebsd) %}
     TIOCGWINSZ = 0x40087468_u64
   {% else %}
     TIOCGWINSZ = 0x5413_u64


### PR DESCRIPTION
## Description

`flag?(:freebsd)` is added in the condition macro so the terminal resize can be supported on FreeBSD.