### PR TITLE
Harden text editor persistence and tab closing

### DIFF
--- a/spec/tui/widgets/tabbed_panel_close_spec.cr
+++ b/spec/tui/widgets/tabbed_panel_close_spec.cr
@@ -1,0 +1,16 @@
+require "../../spec_helper"
+
+describe Tui::TabbedPanel do
+  it "allows a caller to veto a tab close before state is removed" do
+    tabs = Tui::TabbedPanel.new("tabs")
+    tabs.add_tab("dirty", "dirty") { Tui::Label.new("content", "dirty") }
+    close_events = 0
+    tabs.on_before_tab_close { |id| id != "dirty" }
+    tabs.on_tab_close { |_id| close_events += 1 }
+
+    tabs.close_tab("dirty").should be_false
+    tabs.tabs.map(&.id).should eq ["dirty"]
+    tabs.active_tab_id.should eq "dirty"
+    close_events.should eq 0
+  end
+end

--- a/spec/tui/widgets/text_editor_file_spec.cr
+++ b/spec/tui/widgets/text_editor_file_spec.cr
@@ -25,6 +25,34 @@ describe Tui::TextEditor do
     end
   end
 
+  it "atomically replaces the file while preserving permissions" do
+    with_editor_file("before\n") do |editor, path|
+      File.chmod(path, 0o640)
+      original = File.info(path)
+      editor.load_file(path).should be_true
+      editor.text = "after\n"
+
+      editor.save.should be_true
+      replacement = File.info(path)
+      original.same_file?(replacement).should be_false
+      replacement.permissions.to_i.should eq(0o640)
+      File.read(path).should eq("after\n")
+    end
+  end
+
+  it "updates a symlink target without replacing the symlink" do
+    with_editor_file("before\n") do |editor, target|
+      link = target.parent / "sample-link.txt"
+      File.symlink(target.basename.to_s, link)
+      editor.load_file(link).should be_true
+      editor.text = "after\n"
+
+      editor.save.should be_true
+      File.info(link, follow_symlinks: false).symlink?.should be_true
+      File.read(target).should eq("after\n")
+    end
+  end
+
   it "replaces the complete document as one undoable edit" do
     editor = Tui::TextEditor.new("replace-all")
     editor.text = "old old\n"

--- a/spec/tui/widgets/text_editor_file_spec.cr
+++ b/spec/tui/widgets/text_editor_file_spec.cr
@@ -1,0 +1,42 @@
+require "../../spec_helper"
+require "file_utils"
+
+private def with_editor_file(content : String, &)
+  root = Path.new(Dir.tempdir, "text-editor-file-#{Random::Secure.hex(8)}")
+  Dir.mkdir_p(root)
+  path = root / "sample.txt"
+  File.write(path, content)
+  begin
+    yield Tui::TextEditor.new("file-round-trip"), path
+  ensure
+    FileUtils.rm_rf(root)
+  end
+end
+
+describe Tui::TextEditor do
+  it "round-trips final newlines and line-ending style" do
+    ["alpha", "alpha\n", "alpha\n\n", "alpha\r\nbeta\r\n"].each do |content|
+      with_editor_file(content) do |editor, path|
+        editor.load_file(path).should be_true
+        editor.text.should eq content
+        editor.save.should be_true
+        File.read(path).should eq content
+      end
+    end
+  end
+
+  it "replaces the complete document as one undoable edit" do
+    editor = Tui::TextEditor.new("replace-all")
+    editor.text = "old old\n"
+    editor.set_cursor(0, 3)
+
+    editor.replace_text("new new\n").should be_true
+    editor.text.should eq "new new\n"
+    editor.cursor.should eq Tui::TextEditor::Cursor.new(0, 3)
+
+    editor.undo.should be_true
+    editor.text.should eq "old old\n"
+    editor.redo.should be_true
+    editor.text.should eq "new new\n"
+  end
+end

--- a/src/tui/widgets/tabbed_panel.cr
+++ b/src/tui/widgets/tabbed_panel.cr
@@ -53,6 +53,7 @@ module Tui
     property show_close_button : Bool = true
 
     # Callbacks
+    @on_before_tab_close : Proc(String, Bool)?
     @on_tab_close : Proc(String, Nil)?
     @on_tab_switch : Proc(String, Nil)?
 
@@ -129,6 +130,10 @@ module Tui
       @tabs[@active_tab]?.try(&.id)
     end
 
+    def on_before_tab_close(&block : String -> Bool) : Nil
+      @on_before_tab_close = block
+    end
+
     def on_tab_close(&block : String -> Nil) : Nil
       @on_tab_close = block
     end
@@ -140,6 +145,7 @@ module Tui
     def close_tab(id : String) : Bool
       index = @tabs.index { |t| t.id == id }
       return false unless index
+      return false if @on_before_tab_close.try { |callback| !callback.call(id) }
 
       tab = @tabs[index]
       if content = tab.content

--- a/src/tui/widgets/text_editor.cr
+++ b/src/tui/widgets/text_editor.cr
@@ -305,7 +305,7 @@ module Tui
 
     def save_as(path : Path) : Bool
       begin
-        File.write(path.to_s, text)
+        atomic_write(path, text)
         @path = path
         @title = path.basename
         @modified = false
@@ -315,6 +315,39 @@ module Tui
         true
       rescue
         false
+      end
+    end
+
+    private def atomic_write(path : Path, content : String) : Nil
+      target = if File.info?(path, follow_symlinks: false).try(&.symlink?)
+                 Path.new(File.realpath(path))
+               else
+                 path.expand
+               end
+      permissions = File.info?(target).try(&.permissions.to_i)
+      parent = target.parent
+      temporary = File.tempfile(".#{target.basename}.adamantine-", nil, dir: parent.to_s)
+      temporary_path = Path.new(temporary.path)
+      renamed = false
+
+      begin
+        temporary << content
+        temporary.flush
+        File.chmod(temporary_path, permissions) if permissions
+        temporary.fsync
+        temporary.close
+        File.rename(temporary_path, target)
+        renamed = true
+
+        begin
+          File.open(parent.to_s) { |directory| directory.fsync }
+        rescue
+          # Some platforms do not permit opening directories. The file itself
+          # is already durable and atomically visible at this point.
+        end
+      ensure
+        temporary.close unless temporary.closed?
+        File.delete(temporary_path) if !renamed && File.exists?(temporary_path)
       end
     end
 

--- a/src/tui/widgets/text_editor.cr
+++ b/src/tui/widgets/text_editor.cr
@@ -72,6 +72,7 @@ module Tui
     @last_edit_kind : Symbol? = nil
     @recording_undo : Bool = true
     @saved_text : String = ""
+    @line_ending : String = "\n"
 
     UNDO_LIMIT = 100
 
@@ -255,12 +256,11 @@ module Tui
     end
 
     def text : String
-      @lines.join("\n")
+      @lines.join(@line_ending)
     end
 
     def text=(content : String) : Nil
-      @lines = content.lines
-      @lines = [""] if @lines.empty?
+      load_content(content)
       @cursor = Cursor.new
       @selection = nil
       @scroll_x = 0
@@ -274,8 +274,7 @@ module Tui
     def load_file(path : Path) : Bool
       begin
         content = File.read(path.to_s)
-        @lines = content.lines
-        @lines = [""] if @lines.empty?
+        load_content(content)
         @path = path
         @title = path.basename
         @cursor = Cursor.new
@@ -317,6 +316,22 @@ module Tui
       rescue
         false
       end
+    end
+
+    # Replace the complete document as a single undoable edit.
+    # This is intended for transformations such as replace-all and formatting.
+    def replace_text(content : String) : Bool
+      return false if content == text
+
+      begin_edit(nil)
+      line = @cursor.line
+      col = @cursor.col
+      load_content(content)
+      @cursor.line = line.clamp(0, @lines.size - 1)
+      @cursor.col = col.clamp(0, @lines[@cursor.line].size)
+      @selection = nil
+      text_changed
+      true
     end
 
     def can_undo? : Bool
@@ -754,8 +769,7 @@ module Tui
 
     private def restore_edit_state(state : EditState) : Nil
       @recording_undo = false
-      @lines = state.text.lines
-      @lines = [""] if @lines.empty?
+      load_content(state.text)
       @cursor.line = state.line.clamp(0, @lines.size - 1)
       @cursor.col = state.col.clamp(0, @lines[@cursor.line].size)
       @selection = nil
@@ -766,6 +780,24 @@ module Tui
       mark_dirty!
     ensure
       @recording_undo = true
+    end
+
+    private def load_content(content : String) : Nil
+      @line_ending = detect_line_ending(content)
+      @lines = content.split(@line_ending, remove_empty: false)
+      @lines = [""] if @lines.empty?
+    end
+
+    private def detect_line_ending(content : String) : String
+      crlf = content.index("\r\n")
+      lf = content.index('\n')
+      cr = content.index('\r')
+
+      candidates = [] of {Int32, String}
+      candidates << {crlf, "\r\n"} if crlf
+      candidates << {lf, "\n"} if lf && (crlf.nil? || lf != crlf)
+      candidates << {cr, "\r"} if cr && (crlf.nil? || cr != crlf)
+      candidates.min_by?(&.[0]).try(&.[1]) || @line_ending
     end
 
     private def update_selection_start : Nil


### PR DESCRIPTION
## Summary

- preserve the original line-ending style and final-newline state across open/save cycles
- make replace-all a single undoable edit and save atomically in the target directory while preserving permissions and symlink targets
- add a `before_close` callback so consumers can veto destructive tab closure

## Verification

- `crystal spec spec/tui/widgets/text_editor_file_spec.cr spec/tui/widgets/tabbed_panel_close_spec.cr` — 5 examples, 0 failures, 0 errors
- downstream Adamantine clean-clone check fetched this exact commit with `shards install --frozen` and passed format, build, and 335 specs

## Known baseline

The repository-wide crystal_tui suite retains its pre-existing failures in markdown, split-drag, and text-editor mouse cases. The focused persistence and close-veto coverage is green.