### PR TITLE
Use a persistent piece-tree buffer in TextEditor

### DIFF
--- a/spec/tui/piece_tree_buffer_spec.cr
+++ b/spec/tui/piece_tree_buffer_spec.cr
@@ -1,0 +1,336 @@
+require "../spec_helper"
+
+private def utf8_boundaries(text : String) : Array(Int32)
+  offsets = [0] of Int32
+  offset = 0
+  text.each_char do |char|
+    offset += char.bytesize
+    offsets << offset
+  end
+  offsets
+end
+
+private def editable_utf8_boundaries(text : String) : Array(Int32)
+  bytes = text.to_slice
+  utf8_boundaries(text).reject do |offset|
+    offset > 0 && offset < bytes.size && bytes[offset - 1] == '\r'.ord && bytes[offset] == '\n'.ord
+  end
+end
+
+private def reference_lines(text : String) : Array(String)
+  text.split(/\r\n|\r|\n/, remove_empty: false)
+end
+
+private def reference_line_starts(text : String) : Array(Int32)
+  starts = [0] of Int32
+  bytes = text.to_slice
+  offset = 0
+  while offset < bytes.size
+    if bytes[offset] == '\r'.ord && offset + 1 < bytes.size && bytes[offset + 1] == '\n'.ord
+      offset += 2
+      starts << offset
+    elsif bytes[offset] == '\r'.ord || bytes[offset] == '\n'.ord
+      offset += 1
+      starts << offset
+    else
+      offset += 1
+    end
+  end
+  starts
+end
+
+private def splice_reference(text : String, offset : Int32, length : Int32, replacement : String) : String
+  prefix = text.byte_slice(0, offset) || ""
+  suffix_offset = offset + length
+  suffix = text.byte_slice(suffix_offset, text.bytesize - suffix_offset) || ""
+  prefix + replacement + suffix
+end
+
+private def assert_piece_tree_matches(buffer : Tui::PieceTreeBuffer, reference : String) : Nil
+  lines = reference_lines(reference)
+  buffer.text.should eq reference
+  buffer.byte_length.should eq reference.bytesize
+  buffer.line_count.should eq lines.size
+  lines.each_with_index do |expected, index|
+    buffer.line(index).should eq expected
+  end
+
+  utf8_boundaries(reference).each do |offset|
+    next if offset > 0 && offset < reference.bytesize && reference.to_slice[offset - 1] == '\r'.ord && reference.to_slice[offset] == '\n'.ord
+    expected_line = reference_line_starts(reference).count { |start| start <= offset } - 1
+    buffer.line_index_at_offset(offset).should eq expected_line
+  end
+
+  reference_line_starts(reference).each_with_index do |expected_offset, index|
+    buffer.line_start_offset(index).should eq expected_offset
+  end
+
+  buffer.validate!
+end
+
+describe Tui::PieceTreeBuffer do
+  it "initializes from UTF-8 text and exposes logical lines" do
+    buffer = Tui::PieceTreeBuffer.new("alpha\nβeta\n")
+
+    buffer.byte_length.should eq "alpha\nβeta\n".bytesize
+    buffer.line_count.should eq 3
+    buffer.line(0).should eq "alpha"
+    buffer.line(1).should eq "βeta"
+    buffer.line(2).should eq ""
+    buffer.storage_bytesize.should eq buffer.byte_length
+  end
+
+  it "keeps insert and delete byte-oriented" do
+    buffer = Tui::PieceTreeBuffer.new("hello\nworld")
+    buffer.insert("hello".bytesize, ", 世界\n")
+
+    buffer.text.should eq "hello, 世界\n\nworld"
+    buffer.line_count.should eq 3
+    buffer.line(0).should eq "hello, 世界"
+    buffer.line(1).should eq ""
+    buffer.line(2).should eq "world"
+
+    deleted_offset = "hello, ".bytesize
+    buffer.delete(deleted_offset, "世界".bytesize).should eq "世界"
+    buffer.text.should eq "hello, \n\nworld"
+    buffer.validate!
+  end
+
+  it "converts between line indexes and UTF-8 byte offsets" do
+    text = "a\nβb\nlast"
+    buffer = Tui::PieceTreeBuffer.new(text)
+
+    buffer.line_start_offset(0).should eq 0
+    buffer.line_start_offset(1).should eq "a\n".bytesize
+    buffer.line_start_offset(2).should eq "a\nβb\n".bytesize
+
+    buffer.line_index_at_offset(0).should eq 0
+    buffer.line_index_at_offset(1).should eq 0
+    buffer.line_index_at_offset("a\n".bytesize).should eq 1
+    buffer.line_index_at_offset("a\nβ".bytesize).should eq 1
+    buffer.line_index_at_offset(text.bytesize).should eq 2
+
+    trailing_newline = Tui::PieceTreeBuffer.new("#{text}\n")
+    trailing_newline.line_count.should eq 4
+    trailing_newline.line(3).should eq ""
+    trailing_newline.line_index_at_offset(trailing_newline.byte_length).should eq 3
+  end
+
+  it "converts codepoint coordinates without materializing a line" do
+    text = "Aé🙂\n界é"
+    buffer = Tui::PieceTreeBuffer.new(text)
+    boundaries = utf8_boundaries(text)
+
+    boundaries.each_with_index do |offset, codepoint|
+      buffer.codepoint_index_at_offset(offset).should eq codepoint
+      buffer.byte_offset_at_codepoint(codepoint).should eq offset
+    end
+    buffer.line_character_length(0).should eq 3
+    buffer.line_character_length(1).should eq 3 # combining mark is a codepoint
+    buffer.line_slice(0, 1, 2).should eq "é🙂"
+    buffer.character_at(1, 0).should eq '界'
+    buffer.character_at(1, 3).should be_nil
+    expect_raises(ArgumentError) { buffer.byte_offset_at_codepoint(-1) }
+    expect_raises(ArgumentError) { buffer.byte_offset_at_codepoint(boundaries.size) }
+
+    crlf = Tui::PieceTreeBuffer.new("Aé🙂\r\n界é")
+    crlf.line_character_length(0).should eq 3
+    crlf.line_character_length(1).should eq 3
+  end
+
+  it "rejects invalid ranges without changing the buffer" do
+    buffer = Tui::PieceTreeBuffer.new("Aé🙂B")
+    before = buffer.text
+
+    expect_raises(ArgumentError) { buffer.insert(2, "x") }
+    expect_raises(ArgumentError) { buffer.delete(2, 1) }
+    expect_raises(ArgumentError) { buffer.delete(1, 1) }
+    expect_raises(ArgumentError) { buffer.insert(-1, "x") }
+    expect_raises(ArgumentError) { buffer.insert(buffer.byte_length + 1, "x") }
+    expect_raises(ArgumentError) { buffer.delete(0, -1) }
+    expect_raises(ArgumentError) { buffer.delete(buffer.byte_length, 1) }
+    expect_raises(ArgumentError) { buffer.delete(0, buffer.byte_length + 1) }
+    expect_raises(ArgumentError) { buffer.line_index_at_offset(2) }
+    expect_raises(IndexError) { buffer.line_start_offset(-1) }
+    expect_raises(IndexError) { buffer.line_start_offset(buffer.line_count) }
+
+    buffer.text.should eq before
+  end
+
+  it "restores persistent snapshots without copying document storage" do
+    original = "line\n" * 10_000
+    buffer = Tui::PieceTreeBuffer.new(original)
+    snapshot = buffer.snapshot
+    stored_before = buffer.storage_bytesize
+
+    buffer.insert(original.bytesize // 2, "世界")
+    changed = buffer.snapshot
+    buffer.storage_bytesize.should eq stored_before + "世界".bytesize
+
+    buffer.restore(snapshot)
+    buffer.text.should eq original
+    buffer.restore(changed)
+    buffer.text.should eq splice_reference(original, original.bytesize // 2, 0, "世界")
+  end
+
+  it "chunks large sources, streams exact bytes, and stays balanced" do
+    original = String.build do |io|
+      8_000.times { |index| io << index << ": αβγ🙂\r\n" }
+    end
+    buffer = Tui::PieceTreeBuffer.new(original)
+
+    buffer.piece_count.should be > 10
+    buffer.tree_height.should be < 64
+    output = IO::Memory.new
+    buffer.write_to(output).should eq original.bytesize
+    output.to_s.should eq original
+    buffer.line(4_000).ends_with?('\r').should be_false
+
+    crlf = original.index("\r\n").not_nil!
+    expect_raises(ArgumentError) { buffer.insert(crlf + 1, "x") }
+    buffer.validate!
+  end
+
+  it "preserves mixed line endings while indexing them as logical lines" do
+    text = "a\rb\r\nc\nd\r\n"
+    buffer = Tui::PieceTreeBuffer.new(text)
+
+    buffer.text.should eq text
+    buffer.line_count.should eq 5
+    buffer.line(0).should eq "a"
+    buffer.line(1).should eq "b"
+    buffer.line(2).should eq "c"
+    buffer.line(3).should eq "d"
+    buffer.line(4).should eq ""
+    buffer.line_start_offset(1).should eq 2
+    buffer.line_start_offset(2).should eq 5
+    buffer.line_start_offset(3).should eq 7
+    buffer.line_start_offset(4).should eq 10
+    buffer.validate!
+  end
+
+  it "normalizes LF and CRLF exactly once for CR-only streaming" do
+    buffer = Tui::PieceTreeBuffer.new("a\r\nb\nc\r")
+    output = IO::Memory.new
+
+    buffer.write_to(output, lf_as_cr: true).should eq 6
+
+    output.to_s.should eq "a\rb\rc\r"
+  end
+
+  it "finds word boundaries across many pieces without materializing the line" do
+    prefix = "word " * 50_000
+    buffer = Tui::PieceTreeBuffer.new(prefix + "tail")
+    finish = buffer.line_character_length(0)
+
+    buffer.previous_word_column(0, finish).should eq finish - 4
+    buffer.next_word_column(0, 0).should eq 5
+    buffer.next_word_column(0, finish - 4).should eq finish
+    buffer.previous_word_column(0, 0).should eq 0
+  end
+
+  it "keeps multi-megabyte edit history structurally shared" do
+    original = "source line 0123456789\n" * 350_000
+    buffer = Tui::PieceTreeBuffer.new(original)
+    initial = buffer.snapshot
+    snapshots = [] of Tui::PieceTreeBuffer::Snapshot
+    inserted_bytes = 0
+
+    100.times do |index|
+      offset = buffer.byte_length // 2
+      inserted = "<#{index}>"
+      inserted_bytes += inserted.bytesize
+      buffer.insert(offset, inserted)
+      snapshots << buffer.snapshot
+    end
+
+    buffer.storage_bytesize.should eq original.bytesize.to_i64 + inserted_bytes
+    buffer.tree_height.should be < 128
+    buffer.validate!
+
+    buffer.restore(initial)
+    buffer.byte_length.should eq original.bytesize
+    buffer.slice(0, 11).should eq "source line"
+    buffer.restore(snapshots.last)
+    buffer.byte_length.should eq original.bytesize + inserted_bytes
+  end
+
+  it "coalesces consecutive typing in the append-only add store" do
+    buffer = Tui::PieceTreeBuffer.new
+
+    20_000.times { buffer.insert(buffer.byte_length, "x") }
+
+    buffer.byte_length.should eq 20_000
+    buffer.storage_bytesize.should eq 20_000
+    buffer.piece_count.should be <= 3
+    buffer.tree_height.should be <= 3
+    buffer.validate!
+  end
+
+  it "matches a String model through deterministic randomized edits" do
+    seed = 0x50494543
+    random = Random.new(seed)
+    chunks = ["", "a", "é", "🙂", "\n", "x\nβ", "世界", "\n\n"]
+    reference = "α\nseed🙂\n"
+    buffer = Tui::PieceTreeBuffer.new(reference)
+
+    500.times do |step|
+      boundaries = utf8_boundaries(reference)
+      start_index = random.rand(boundaries.size)
+      offset = boundaries[start_index]
+
+      if random.rand(100) < 60
+        inserted = chunks[random.rand(chunks.size)]
+        buffer.insert(offset, inserted)
+        reference = splice_reference(reference, offset, 0, inserted)
+      else
+        end_index = start_index + random.rand(boundaries.size - start_index)
+        end_offset = boundaries[end_index]
+        length = end_offset - offset
+        expected_deleted = reference.byte_slice(offset, length) || ""
+        buffer.delete(offset, length).should eq expected_deleted
+        reference = splice_reference(reference, offset, length, "")
+      end
+
+      begin
+        assert_piece_tree_matches(buffer, reference)
+      rescue ex
+        raise "seed #{seed}, edit #{step}, reference #{reference.inspect}: #{ex.message}"
+      end
+    end
+  end
+
+  it "matches a String model across randomized CRLF boundary edits" do
+    chunks = ["a", "é", "🙂", "\r\n", "x\r\nβ", "世界", "\n", "\r"]
+
+    [0x43524c46, 0x50494543, 0x54524545, 0x554e4943].each do |seed|
+      random = Random.new(seed)
+      reference = "α\r\nseed🙂\r\n"
+      buffer = Tui::PieceTreeBuffer.new(reference)
+
+      300.times do |step|
+        boundaries = editable_utf8_boundaries(reference)
+        start_index = random.rand(boundaries.size)
+        offset = boundaries[start_index]
+
+        if random.rand(100) < 60
+          inserted = chunks[random.rand(chunks.size)]
+          buffer.insert(offset, inserted)
+          reference = splice_reference(reference, offset, 0, inserted)
+        else
+          end_index = start_index + random.rand(boundaries.size - start_index)
+          end_offset = boundaries[end_index]
+          length = end_offset - offset
+          buffer.delete(offset, length).should eq(reference.byte_slice(offset, length) || "")
+          reference = splice_reference(reference, offset, length, "")
+        end
+
+        begin
+          assert_piece_tree_matches(buffer, reference)
+        rescue ex
+          raise "seed #{seed}, edit #{step}, reference #{reference.inspect}: #{ex.message}"
+        end
+      end
+    end
+  end
+end

--- a/spec/tui/widgets/piece_tree_text_editor_spec.cr
+++ b/spec/tui/widgets/piece_tree_text_editor_spec.cr
@@ -1,0 +1,114 @@
+require "../../spec_helper"
+
+private def piece_tree_editor(id : String, content : String = "") : Tui::TextEditor
+  editor = Tui::TextEditor.new(id)
+  editor.rect = Tui::Rect.new(0, 0, 80, 12)
+  editor.text = content unless content.empty?
+  editor.focus
+  editor
+end
+
+describe Tui::TextEditor do
+  it "keeps cursor columns character-indexed across Unicode edits and undo" do
+    editor = piece_tree_editor("piece-tree-unicode", "a🙂界\n終")
+    editor.set_cursor(0, 2)
+
+    editor.insert_char('🚀')
+    editor.cursor.should eq Tui::TextEditor::Cursor.new(0, 3)
+    editor.text.should eq "a🙂🚀界\n終"
+
+    editor.backspace
+    editor.cursor.should eq Tui::TextEditor::Cursor.new(0, 2)
+    editor.text.should eq "a🙂界\n終"
+
+    editor.select_range(0, 1, 0, 3)
+    editor.copy.should eq "🙂界"
+    editor.delete_selection
+    editor.text.should eq "a\n終"
+    editor.undo.should be_true
+    editor.text.should eq "a🙂界\n終"
+    editor.cursor.should eq Tui::TextEditor::Cursor.new(0, 3)
+
+    editor.undo.should be_true
+    editor.text.should eq "a🙂🚀界\n終"
+    editor.cursor.should eq Tui::TextEditor::Cursor.new(0, 3)
+
+    editor.undo.should be_true
+    editor.text.should eq "a🙂界\n終"
+    editor.cursor.should eq Tui::TextEditor::Cursor.new(0, 2)
+  end
+
+  it "edits and undoes homogeneous LF, CRLF, and CR documents" do
+    ["\n", "\r\n", "\r"].each do |ending|
+      editor = piece_tree_editor("piece-tree-ending-#{ending.bytesize}", "left#{ending}right")
+      editor.set_cursor(0, 4)
+      editor.insert_newline
+      editor.text.should eq "left#{ending}#{ending}right"
+      editor.cursor.should eq Tui::TextEditor::Cursor.new(1, 0)
+
+      editor.backspace
+      editor.text.should eq "left#{ending}right"
+      editor.undo.should be_true
+      editor.text.should eq "left#{ending}#{ending}right"
+      editor.redo.should be_true
+      editor.text.should eq "left#{ending}right"
+    end
+  end
+
+  it "preserves mixed line endings and uses the first style for new lines" do
+    editor = piece_tree_editor("piece-tree-mixed-ending", "a\rb\r\nc\nd")
+
+    editor.text.should eq "a\rb\r\nc\nd"
+    editor.set_cursor(2, 1)
+    editor.insert_newline
+    editor.text.should eq "a\rb\r\nc\r\n\nd"
+    editor.lines.should eq ["a", "b", "c", "", "d"]
+    editor.undo.should be_true
+    editor.text.should eq "a\rb\r\nc\nd"
+  end
+
+  it "does not merge untouched CR and LF separators when deleting line content" do
+    editor = piece_tree_editor("piece-tree-mixed-delete", "a\rX\nb")
+    editor.set_cursor(1, 1)
+
+    editor.backspace
+
+    editor.lines.should eq ["a", "", "b"]
+    editor.text.should eq "a\r\r\nb"
+    editor.undo.should be_true
+    editor.text.should eq "a\rX\nb"
+  end
+
+  it "round-trips a large document through many structural undo states" do
+    original = String.build do |io|
+      12_000.times do |index|
+        io << "line-" << index << ": αβγ🙂" << "\n"
+      end
+    end
+    editor = piece_tree_editor("piece-tree-large", original)
+    editor.set_cursor(0, 0)
+
+    100.times { editor.insert_text("x") }
+    changed = "x" * 100 + original
+    editor.text.should eq changed
+
+    100.times { editor.undo.should be_true }
+    editor.text.should eq original
+    editor.cursor.should eq Tui::TextEditor::Cursor.new(0, 0)
+
+    100.times { editor.redo.should be_true }
+    editor.text.should eq changed
+    editor.cursor.should eq Tui::TextEditor::Cursor.new(0, 100)
+  end
+
+  it "renders a viewport from a multi-megabyte single line" do
+    editor = piece_tree_editor("piece-tree-wide-line", "prefix-" + "x" * 8_000_000 + "-suffix")
+    editor.set_cursor(0, 8_000_007)
+    buffer = Tui::Buffer.new(80, 12)
+
+    editor.render(buffer, editor.rect)
+
+    buffer.get(7, 0).glyph.should eq "x"
+    buffer.get(77, 0).glyph.should eq "x"
+  end
+end

--- a/spec/tui/widgets/text_editor_file_spec.cr
+++ b/spec/tui/widgets/text_editor_file_spec.cr
@@ -15,7 +15,7 @@ end
 
 describe Tui::TextEditor do
   it "round-trips final newlines and line-ending style" do
-    ["alpha", "alpha\n", "alpha\n\n", "alpha\r\nbeta\r\n"].each do |content|
+    ["alpha", "alpha\n", "alpha\n\n", "alpha\r\nbeta\r\n", "alpha\rbeta\r", "a\rb\r\nc\nd\r\n"].each do |content|
       with_editor_file(content) do |editor, path|
         editor.load_file(path).should be_true
         editor.text.should eq content
@@ -66,5 +66,13 @@ describe Tui::TextEditor do
     editor.text.should eq "old old\n"
     editor.redo.should be_true
     editor.text.should eq "new new\n"
+  end
+
+  it "keeps the legacy public EditState constructor" do
+    state = Tui::TextEditor::EditState.new("alpha\r\nbeta", 1, 2)
+
+    state.text.should eq "alpha\r\nbeta"
+    state.line.should eq 1
+    state.col.should eq 2
   end
 end

--- a/src/tui.cr
+++ b/src/tui.cr
@@ -44,6 +44,7 @@ require "./tui/unicode"
 # Widgets
 require "./tui/reactive"
 require "./tui/widget"
+require "./tui/text/piece_tree_buffer"
 
 # Containers
 require "./tui/containers/vbox"

--- a/src/tui/text/piece_tree_buffer.cr
+++ b/src/tui/text/piece_tree_buffer.cr
@@ -1,0 +1,934 @@
+require "set"
+
+module Tui
+  # UTF-8 text storage for editors. The document is represented as a persistent
+  # implicit treap of pieces into immutable source strings. Edits path-copy only
+  # the affected tree nodes, so snapshots used by undo share document storage.
+  class PieceTreeBuffer
+    TARGET_PIECE_BYTES = 4 * 1024
+    MIN_PIECE_BYTES    = 2 * 1024
+    MAX_PIECE_BYTES    = 8 * 1024
+    MAX_TREE_HEIGHT    = 64
+
+    private alias Source = String | IO::Memory
+
+    private struct Piece
+      getter source : Source
+      getter start : Int32
+      getter length : Int32
+      getter newlines : Int32
+      getter codepoints : Int32
+      getter starts_with_lf : Bool
+      getter ends_with_cr : Bool
+
+      def initialize(
+        @source : Source,
+        @start : Int32,
+        @length : Int32,
+        @newlines : Int32,
+        @codepoints : Int32,
+        @starts_with_lf : Bool,
+        @ends_with_cr : Bool,
+      )
+      end
+    end
+
+    private struct SourceRange
+      getter source : Source
+      getter start : Int32
+      getter length : Int32
+
+      def initialize(@source : Source, @start : Int32, @length : Int32)
+      end
+    end
+
+    private class Node
+      getter piece : Piece
+      getter left : Node?
+      getter right : Node?
+      getter priority : UInt64
+      getter byte_length : Int32
+      getter newline_count : Int32
+      getter codepoint_count : Int32
+      getter piece_count : Int32
+      getter height : Int32
+      getter starts_with_lf : Bool
+      getter ends_with_cr : Bool
+
+      def initialize(@piece : Piece, @priority : UInt64, @left : Node? = nil, @right : Node? = nil)
+        @byte_length = PieceTreeBuffer.node_bytes(@left) + @piece.length + PieceTreeBuffer.node_bytes(@right)
+        @newline_count = PieceTreeBuffer.node_newlines(@left) + @piece.newlines + PieceTreeBuffer.node_newlines(@right)
+        @newline_count -= 1 if @left.try(&.ends_with_cr) && @piece.starts_with_lf
+        @newline_count -= 1 if @piece.ends_with_cr && @right.try(&.starts_with_lf)
+        @codepoint_count = PieceTreeBuffer.node_codepoints(@left) + @piece.codepoints + PieceTreeBuffer.node_codepoints(@right)
+        @piece_count = PieceTreeBuffer.node_count(@left) + 1 + PieceTreeBuffer.node_count(@right)
+        @height = 1 + Math.max(PieceTreeBuffer.node_height(@left), PieceTreeBuffer.node_height(@right))
+        @starts_with_lf = @left ? @left.not_nil!.starts_with_lf : @piece.starts_with_lf
+        @ends_with_cr = @right ? @right.not_nil!.ends_with_cr : @piece.ends_with_cr
+      end
+    end
+
+    private class SnapshotToken
+    end
+
+    # An immutable, O(1) handle to a structurally shared document root.
+    class Snapshot
+      protected getter token : SnapshotToken
+      protected getter root : Node?
+
+      protected def initialize(@token : SnapshotToken, @root : Node?)
+      end
+
+      def byte_length : Int32
+        PieceTreeBuffer.node_bytes(@root)
+      end
+
+      def text : String
+        String.build(byte_length) { |io| write_node(io, @root) }
+      end
+
+      def write_to(io : IO) : Int32
+        write_node(io, @root)
+        byte_length
+      end
+
+      private def write_node(io : IO, node : Node?) : Nil
+        return unless node
+        write_node(io, node.left)
+        source = node.piece.source
+        io.write(source.to_slice[node.piece.start, node.piece.length])
+        write_node(io, node.right)
+      end
+    end
+
+    @root : Node?
+    @add_page = IO::Memory.new
+    @priority_state : UInt64 = 0x9e3779b97f4a7c15_u64
+    @snapshot_token = SnapshotToken.new
+
+    def initialize(text : String = "")
+      @root = nil
+      reset(text)
+    end
+
+    def byte_length : Int32
+      self.class.node_bytes(@root)
+    end
+
+    def byte_at_offset(offset : Int32) : UInt8?
+      raise ArgumentError.new("offset outside buffer") unless offset >= 0 && offset <= byte_length
+      return nil if offset == byte_length
+      byte_at(@root, offset)
+    end
+
+    def line_count : Int32
+      self.class.node_newlines(@root) + 1
+    end
+
+    # Source bytes reachable from the active root plus the current append page.
+    # Sources reachable only from older snapshots are intentionally not
+    # discoverable from the active buffer.
+    def storage_bytesize : Int64
+      seen = Set(UInt64).new
+      total = source_bytes(@root, seen)
+      unless seen.includes?(@add_page.object_id)
+        total += @add_page.to_slice.size
+      end
+      total
+    end
+
+    def text : String
+      slice(0, byte_length)
+    end
+
+    def line(index : Int32) : String
+      start, finish = line_content_range(index)
+      slice(start, finish - start)
+    end
+
+    def each_line(& : String ->) : Nil
+      line_count.times { |index| yield line(index) }
+    end
+
+    def line_start_offset(index : Int32) : Int32
+      raise IndexError.new("line index #{index} outside 0...#{line_count}") unless index >= 0 && index < line_count
+      return 0 if index == 0
+      newline_offset(@root, index, 0, false) + 1
+    end
+
+    def line_character_length(index : Int32) : Int32
+      start, finish = line_content_range(index)
+      codepoint_index_at_offset(finish) - codepoint_index_at_offset(start)
+    end
+
+    def line_slice(index : Int32, start_column : Int32, count : Int32) : String
+      raise ArgumentError.new("column and count must not be negative") if start_column < 0 || count < 0
+      start, finish = line_content_range(index)
+      first_codepoint = codepoint_index_at_offset(start)
+      available = codepoint_index_at_offset(finish) - first_codepoint
+      raise ArgumentError.new("column outside line") if start_column > available
+      take = Math.min(count, available - start_column)
+      from = byte_offset_at_codepoint(first_codepoint + start_column)
+      to = byte_offset_at_codepoint(first_codepoint + start_column + take)
+      slice(from, to - from)
+    end
+
+    def character_at(line : Int32, column : Int32) : Char?
+      return nil if column < 0 || column >= line_character_length(line)
+      start, _finish = line_content_range(line)
+      first_codepoint = codepoint_index_at_offset(start)
+      offset = byte_offset_at_codepoint(first_codepoint + column)
+      character_at_offset(offset)
+    end
+
+    # Returns the word-motion destination without materializing the line and
+    # without doing a tree lookup for every character crossed.
+    def previous_word_column(line : Int32, column : Int32) : Int32
+      start, finish = line_content_range(line)
+      length = codepoint_index_at_offset(finish) - codepoint_index_at_offset(start)
+      raise ArgumentError.new("column outside line") unless column >= 0 && column <= length
+      return 0 if column == 0
+
+      first_codepoint = codepoint_index_at_offset(start)
+      offset = byte_offset_at_codepoint(first_codepoint + column)
+      result = column
+      skipping_whitespace = true
+      each_character_reverse(start, offset) do |char|
+        if skipping_whitespace
+          if char.whitespace?
+            result -= 1
+            true
+          else
+            skipping_whitespace = false
+            result -= 1
+            true
+          end
+        elsif char.whitespace?
+          false
+        else
+          result -= 1
+          true
+        end
+      end
+      result
+    end
+
+    # Returns the word-motion destination without materializing the line and
+    # without doing a tree lookup for every character crossed.
+    def next_word_column(line : Int32, column : Int32) : Int32
+      start, finish = line_content_range(line)
+      first_codepoint = codepoint_index_at_offset(start)
+      length = codepoint_index_at_offset(finish) - first_codepoint
+      raise ArgumentError.new("column outside line") unless column >= 0 && column <= length
+      return length if column == length
+
+      offset = byte_offset_at_codepoint(first_codepoint + column)
+      result = column
+      skipping_word = true
+      each_character_forward(offset, finish) do |char|
+        if skipping_word
+          if char.whitespace?
+            skipping_word = false
+            result += 1
+            true
+          else
+            result += 1
+            true
+          end
+        elsif char.whitespace?
+          result += 1
+          true
+        else
+          false
+        end
+      end
+      result
+    end
+
+    def codepoint_index_at_offset(offset : Int32) : Int32
+      validate_boundary(offset)
+      count_codepoints_before(@root, offset)
+    end
+
+    def byte_offset_at_codepoint(index : Int32) : Int32
+      total = self.class.node_codepoints(@root)
+      raise ArgumentError.new("codepoint index outside buffer") unless index >= 0 && index <= total
+      codepoint_offset(@root, index, 0)
+    end
+
+    # Returns the zero-based logical line containing +offset+. A newline byte
+    # belongs to the line before it; EOF after a final newline is the empty
+    # trailing line.
+    def line_index_at_offset(offset : Int32) : Int32
+      validate_boundary(offset)
+      low = 1
+      high = self.class.node_newlines(@root)
+      found = 0
+      while low <= high
+        middle = low + (high - low) // 2
+        if newline_offset(@root, middle, 0, false) < offset
+          found = middle
+          low = middle + 1
+        else
+          high = middle - 1
+        end
+      end
+      found
+    end
+
+    def insert(offset : Int32, value : String) : Nil
+      validate_boundary(offset)
+      raise ArgumentError.new("inserted text must be valid UTF-8") unless value.valid_encoding?
+      return if value.empty?
+
+      inserted = tree_for_insert(value)
+      left, right = split(@root, offset)
+      @root = concatenate(concatenate(left, inserted), right)
+      ensure_height_bound!
+    end
+
+    def delete(offset : Int32, length : Int32) : String
+      validate_range(offset, length)
+      return "" if length == 0
+
+      deleted = slice(offset, length)
+      left, suffix = split(@root, offset)
+      _removed, right = split(suffix, length)
+      @root = concatenate(left, right)
+      ensure_height_bound!
+      deleted
+    end
+
+    # Replaces the active root while keeping previous source storage valid for
+    # existing snapshots. This is used for undoable whole-document operations.
+    def replace_all(value : String) : Nil
+      raise ArgumentError.new("replacement text must be valid UTF-8") unless value.valid_encoding?
+      @root = if value.empty?
+                nil
+              else
+                tree_for_source(value)
+              end
+      ensure_height_bound!
+    end
+
+    # Resets storage and invalidates snapshots. Callers must clear history first.
+    def reset(value : String = "") : Nil
+      raise ArgumentError.new("buffer text must be valid UTF-8") unless value.valid_encoding?
+      @add_page = IO::Memory.new
+      @snapshot_token = SnapshotToken.new
+      @root = if value.empty?
+                nil
+              else
+                tree_for_source(value)
+              end
+      ensure_height_bound!
+    end
+
+    def snapshot : Snapshot
+      Snapshot.new(@snapshot_token, @root)
+    end
+
+    def restore(snapshot : Snapshot) : Nil
+      unless snapshot.token.same?(@snapshot_token)
+        raise ArgumentError.new("snapshot belongs to stale or different buffer storage")
+      end
+      @root = snapshot.root
+    end
+
+    def same_state?(snapshot : Snapshot) : Bool
+      return false unless snapshot.token.same?(@snapshot_token)
+      roots_same?(@root, snapshot.root)
+    end
+
+    # Checks source ranges, UTF-8 boundaries, heap ordering, and cached metrics.
+    # Intended for tests and diagnostics rather than ordinary edit paths.
+    def validate! : Nil
+      validate_node!(@root)
+    end
+
+    def write_to(io : IO, *, lf_as_cr : Bool = false) : Int32
+      if lf_as_cr
+        _previous_was_cr, written = write_node_as_cr(io, @root, false)
+        written
+      else
+        write_node(io, @root)
+        byte_length
+      end
+    end
+
+    # These diagnostics make balancing and fragmentation observable in tests.
+    def piece_count : Int32
+      self.class.node_count(@root)
+    end
+
+    def tree_height : Int32
+      self.class.node_height(@root)
+    end
+
+    protected def self.node_bytes(node : Node?) : Int32
+      node.try(&.byte_length) || 0
+    end
+
+    protected def self.node_newlines(node : Node?) : Int32
+      node.try(&.newline_count) || 0
+    end
+
+    protected def self.node_codepoints(node : Node?) : Int32
+      node.try(&.codepoint_count) || 0
+    end
+
+    protected def self.node_count(node : Node?) : Int32
+      node.try(&.piece_count) || 0
+    end
+
+    protected def self.node_height(node : Node?) : Int32
+      node.try(&.height) || 0
+    end
+
+    private def tree_for_source(value : String) : Node?
+      tree_for_source(value, value, 0)
+    end
+
+    private def tree_for_insert(value : String) : Node?
+      root = nil.as(Node?)
+      value_start = 0
+      while value_start < value.bytesize
+        page_start = @add_page.to_slice.size
+        available = MAX_PIECE_BYTES - page_start
+        if available == 0
+          @add_page = IO::Memory.new
+          next
+        end
+
+        length = Math.min(next_piece_length(value, value_start), available)
+        while length > 0 && value_start + length < value.bytesize && value.to_unsafe[value_start + length] & 0xc0 == 0x80
+          length -= 1
+        end
+        if length > 0 && value_start + length < value.bytesize &&
+           value.to_unsafe[value_start + length - 1] == '\r'.ord && value.to_unsafe[value_start + length] == '\n'.ord
+          length -= 1
+        end
+        if length == 0
+          @add_page = IO::Memory.new
+          next
+        end
+
+        @add_page.write(value.to_slice[value_start, length])
+        root = concatenate(root, new_node(piece(@add_page, page_start, length)))
+        value_start += length
+      end
+      root
+    end
+
+    private def tree_for_source(source : Source, value : String, source_start : Int32) : Node?
+      root = nil.as(Node?)
+      start = 0
+      while start < value.bytesize
+        length = next_piece_length(value, start)
+        root = merge(root, new_node(piece(source, source_start + start, length)))
+        start += length
+      end
+      root
+    end
+
+    private def next_piece_length(value : String, start : Int32) : Int32
+      remaining = value.bytesize - start
+      return remaining if remaining <= MAX_PIECE_BYTES
+
+      minimum = start + MIN_PIECE_BYTES
+      cut = start + TARGET_PIECE_BYTES
+
+      # Prefer ending just after a nearby LF so line lookup scans less text.
+      probe = cut
+      while probe > minimum
+        if value.to_unsafe[probe - 1] == '\n'.ord
+          cut = probe
+          break
+        end
+        probe -= 1
+      end
+
+      # Move off UTF-8 continuation bytes and never split a CRLF pair.
+      while cut > start && value.to_unsafe[cut] & 0xc0 == 0x80
+        cut -= 1
+      end
+      cut -= 1 if cut > start && value.to_unsafe[cut - 1] == '\r'.ord && value.to_unsafe[cut] == '\n'.ord
+
+      # The target is far beyond the longest UTF-8 scalar, but keep a bounded
+      # forward fallback for defensive completeness.
+      if cut == start
+        cut = start + TARGET_PIECE_BYTES
+        while cut < start + MAX_PIECE_BYTES && value.to_unsafe[cut] & 0xc0 == 0x80
+          cut += 1
+        end
+        cut += 1 if value.to_unsafe[cut - 1] == '\r'.ord && value.to_unsafe[cut] == '\n'.ord
+      end
+
+      cut - start
+    end
+
+    private def piece(source : Source, start : Int32, length : Int32) : Piece
+      bytes = source.to_slice
+      Piece.new(
+        source,
+        start,
+        length,
+        count_newlines(source, start, length),
+        count_codepoints(source, start, length),
+        bytes[start] == '\n'.ord,
+        bytes[start + length - 1] == '\r'.ord
+      )
+    end
+
+    private def new_node(piece : Piece, left : Node? = nil, right : Node? = nil, priority : UInt64 = next_priority) : Node
+      Node.new(piece, priority, left, right)
+    end
+
+    private def rebuild(node : Node, left : Node?, right : Node?) : Node
+      Node.new(node.piece, node.priority, left, right)
+    end
+
+    private def next_priority : UInt64
+      state = @priority_state
+      state ^= state << 13
+      state ^= state >> 7
+      state ^= state << 17
+      @priority_state = state
+      state
+    end
+
+    private def split(node : Node?, offset : Int32) : Tuple(Node?, Node?)
+      return {nil, nil} unless node
+
+      left_bytes = self.class.node_bytes(node.left)
+      piece_end = left_bytes + node.piece.length
+      if offset < left_bytes
+        before, after = split(node.left, offset)
+        {before, rebuild(node, after, node.right)}
+      elsif offset > piece_end
+        before, after = split(node.right, offset - piece_end)
+        {rebuild(node, node.left, before), after}
+      elsif offset == left_bytes
+        {node.left, rebuild(node, nil, node.right)}
+      elsif offset == piece_end
+        {rebuild(node, node.left, nil), node.right}
+      else
+        local = offset - left_bytes
+        left_piece = piece(node.piece.source, node.piece.start, local)
+        right_piece = piece(node.piece.source, node.piece.start + local, node.piece.length - local)
+        # Both fragments inherit the original node's priority. This preserves
+        # the heap bound promised to ancestors on both sides of the split.
+        {merge(node.left, new_node(left_piece, priority: node.priority)), merge(new_node(right_piece, priority: node.priority), node.right)}
+      end
+    end
+
+    private def merge(left : Node?, right : Node?) : Node?
+      return right unless left
+      return left unless right
+
+      if left.priority >= right.priority
+        rebuild(left, left.left, merge(left.right, right))
+      else
+        rebuild(right, merge(left, right.left), right.right)
+      end
+    end
+
+    private def concatenate(left : Node?, right : Node?) : Node?
+      return right unless left
+      return left unless right
+
+      left_rest, left_piece = pop_rightmost(left)
+      right_piece, right_rest = pop_leftmost(right)
+      if left_piece.source.object_id == right_piece.source.object_id &&
+         left_piece.start + left_piece.length == right_piece.start &&
+         left_piece.length + right_piece.length <= MAX_PIECE_BYTES
+        combined = Piece.new(
+          left_piece.source,
+          left_piece.start,
+          left_piece.length + right_piece.length,
+          left_piece.newlines + right_piece.newlines - (left_piece.ends_with_cr && right_piece.starts_with_lf ? 1 : 0),
+          left_piece.codepoints + right_piece.codepoints,
+          left_piece.starts_with_lf,
+          right_piece.ends_with_cr
+        )
+        merge(merge(left_rest, new_node(combined)), right_rest)
+      else
+        merge(left, right)
+      end
+    end
+
+    private def pop_rightmost(node : Node) : Tuple(Node?, Piece)
+      if right = node.right
+        rest, piece = pop_rightmost(right)
+        {rebuild(node, node.left, rest), piece}
+      else
+        {node.left, node.piece}
+      end
+    end
+
+    private def pop_leftmost(node : Node) : Tuple(Piece, Node?)
+      if left = node.left
+        piece, rest = pop_leftmost(left)
+        {piece, rebuild(node, rest, node.right)}
+      else
+        {node.piece, node.right}
+      end
+    end
+
+    def slice(offset : Int32, length : Int32) : String
+      validate_range(offset, length)
+      return "" if length == 0
+
+      String.build(length) do |io|
+        append_range(io, @root, offset, length)
+      end
+    end
+
+    private def write_node(io : IO, node : Node?) : Nil
+      return unless node
+      write_node(io, node.left)
+      source = node.piece.source
+      io.write(source.to_slice[node.piece.start, node.piece.length])
+      write_node(io, node.right)
+    end
+
+    # Compatibility encoder for CR-only consumers. CRLF is collapsed to one
+    # CR even when the pair crosses a piece boundary.
+    private def write_node_as_cr(io : IO, node : Node?, previous_was_cr : Bool) : Tuple(Bool, Int32)
+      return {previous_was_cr, 0} unless node
+
+      previous_was_cr, written = write_node_as_cr(io, node.left, previous_was_cr)
+      bytes = node.piece.source.to_slice[node.piece.start, node.piece.length]
+      bytes.each do |byte|
+        if byte == '\n'.ord
+          unless previous_was_cr
+            io.write_byte('\r'.ord.to_u8)
+            written += 1
+          end
+        else
+          io.write_byte(byte)
+          written += 1
+        end
+        previous_was_cr = byte == '\r'.ord
+      end
+      previous_was_cr, right_written = write_node_as_cr(io, node.right, previous_was_cr)
+      {previous_was_cr, written + right_written}
+    end
+
+    private def source_bytes(node : Node?, seen : Set(UInt64)) : Int64
+      return 0_i64 unless node
+      total = source_bytes(node.left, seen) + source_bytes(node.right, seen)
+      id = node.piece.source.object_id
+      unless seen.includes?(id)
+        seen.add(id)
+        total += node.piece.source.to_slice.size
+      end
+      total
+    end
+
+    private def ensure_height_bound! : Nil
+      return if self.class.node_height(@root) <= MAX_TREE_HEIGHT
+
+      pieces = [] of Piece
+      collect_pieces(@root, pieces)
+      @root = build_balanced(pieces, 0, pieces.size, 0)
+    end
+
+    private def collect_pieces(node : Node?, pieces : Array(Piece)) : Nil
+      return unless node
+      collect_pieces(node.left, pieces)
+      pieces << node.piece
+      collect_pieces(node.right, pieces)
+    end
+
+    private def build_balanced(pieces : Array(Piece), start : Int32, finish : Int32, depth : Int32) : Node?
+      return nil if start >= finish
+      middle = start + (finish - start) // 2
+      left = build_balanced(pieces, start, middle, depth + 1)
+      right = build_balanced(pieces, middle + 1, finish, depth + 1)
+      Node.new(pieces[middle], UInt64::MAX - depth.to_u64, left, right)
+    end
+
+    private def append_range(io : IO, node : Node?, offset : Int32, length : Int32) : Nil
+      return unless node
+      return if length <= 0
+
+      left_bytes = self.class.node_bytes(node.left)
+      if offset < left_bytes
+        take = Math.min(length, left_bytes - offset)
+        append_range(io, node.left, offset, take)
+        length -= take
+        offset = left_bytes
+      end
+      return if length <= 0
+
+      local = offset - left_bytes
+      if local < node.piece.length
+        take = Math.min(length, node.piece.length - local)
+        source = node.piece.source
+        io.write(source.to_slice[node.piece.start + local, take])
+        length -= take
+        local += take
+      end
+      return if length <= 0
+
+      append_range(io, node.right, local - node.piece.length, length)
+    end
+
+    private def character_at_offset(offset : Int32) : Char
+      first_byte = byte_at(@root, offset)
+      width = if first_byte < 0x80
+                1
+              elsif first_byte < 0xe0
+                2
+              elsif first_byte < 0xf0
+                3
+              else
+                4
+              end
+      Char::Reader.new(slice(offset, width)).current_char
+    end
+
+    private def each_character_forward(start : Int32, finish : Int32, &block : Char -> Bool) : Nil
+      ranges = [] of SourceRange
+      collect_source_ranges(@root, start, finish, 0, ranges)
+      ranges.each do |range|
+        chunk = String.new(range.source.to_slice[range.start, range.length])
+        reader = Char::Reader.new(chunk)
+        while reader.has_next?
+          return unless yield reader.current_char
+          reader.next_char
+        end
+      end
+    end
+
+    private def each_character_reverse(start : Int32, finish : Int32, &block : Char -> Bool) : Nil
+      ranges = [] of SourceRange
+      collect_source_ranges(@root, start, finish, 0, ranges)
+      ranges.reverse_each do |range|
+        chunk = String.new(range.source.to_slice[range.start, range.length])
+        reader = Char::Reader.new(at_end: chunk)
+        loop do
+          return unless yield reader.current_char
+          break unless reader.has_previous?
+          reader.previous_char
+        end
+      end
+    end
+
+    private def collect_source_ranges(node : Node?, start : Int32, finish : Int32, base : Int32, ranges : Array(SourceRange)) : Nil
+      return unless node
+      return if start >= finish || finish <= base || start >= base + node.byte_length
+
+      piece_start = base + self.class.node_bytes(node.left)
+      piece_finish = piece_start + node.piece.length
+      collect_source_ranges(node.left, start, finish, base, ranges)
+
+      if start < piece_finish && finish > piece_start
+        local_start = Math.max(start, piece_start) - piece_start
+        local_finish = Math.min(finish, piece_finish) - piece_start
+        ranges << SourceRange.new(node.piece.source, node.piece.start + local_start, local_finish - local_start)
+      end
+
+      collect_source_ranges(node.right, start, finish, piece_finish, ranges)
+    end
+
+    private def line_content_range(index : Int32) : Tuple(Int32, Int32)
+      start = line_start_offset(index)
+      terminated = index + 1 < line_count
+      finish = terminated ? line_start_offset(index + 1) - 1 : byte_length
+      finish -= 1 if terminated && finish > start && byte_at(@root, finish - 1) == '\r'.ord
+      {start, finish}
+    end
+
+    private def newline_offset(node : Node?, ordinal : Int32, base : Int32, next_starts_lf : Bool) : Int32
+      raise IndexError.new("newline ordinal outside buffer") unless node
+
+      left_bytes = self.class.node_bytes(node.left)
+      left_newlines = effective_newlines(node.left, node.piece.starts_with_lf)
+      if ordinal <= left_newlines
+        return newline_offset(node.left, ordinal, base, node.piece.starts_with_lf)
+      end
+
+      within_piece = ordinal - left_newlines
+      following_starts_lf = node.right ? node.right.not_nil!.starts_with_lf : next_starts_lf
+      piece_newlines = node.piece.newlines
+      piece_newlines -= 1 if node.piece.ends_with_cr && following_starts_lf
+      if within_piece <= piece_newlines
+        source = node.piece.source
+        bytes = source.to_slice
+        seen = 0
+        node.piece.length.times do |index|
+          byte = bytes[node.piece.start + index]
+          next_byte_is_lf = if index + 1 < node.piece.length
+                              bytes[node.piece.start + index + 1] == '\n'.ord
+                            else
+                              following_starts_lf
+                            end
+          if byte == '\n'.ord || (byte == '\r'.ord && !next_byte_is_lf)
+            seen += 1
+            return base + left_bytes + index if seen == within_piece
+          end
+        end
+      end
+
+      newline_offset(
+        node.right,
+        within_piece - piece_newlines,
+        base + left_bytes + node.piece.length,
+        next_starts_lf
+      )
+    end
+
+    private def effective_newlines(node : Node?, next_starts_lf : Bool) : Int32
+      return 0 unless node
+      count = node.newline_count
+      count -= 1 if node.ends_with_cr && next_starts_lf
+      count
+    end
+
+    private def count_codepoints_before(node : Node?, offset : Int32) : Int32
+      return 0 unless node
+
+      left_bytes = self.class.node_bytes(node.left)
+      if offset <= left_bytes
+        return count_codepoints_before(node.left, offset)
+      end
+
+      count = self.class.node_codepoints(node.left)
+      local = offset - left_bytes
+      take = Math.min(local, node.piece.length)
+      count += count_codepoints(node.piece.source, node.piece.start, take)
+      return count if local <= node.piece.length
+
+      count + count_codepoints_before(node.right, local - node.piece.length)
+    end
+
+    private def codepoint_offset(node : Node?, ordinal : Int32, base : Int32) : Int32
+      return base unless node
+
+      left_codepoints = self.class.node_codepoints(node.left)
+      left_bytes = self.class.node_bytes(node.left)
+      if ordinal < left_codepoints
+        return codepoint_offset(node.left, ordinal, base)
+      end
+
+      within_piece = ordinal - left_codepoints
+      if within_piece < node.piece.codepoints
+        bytes = node.piece.source.to_slice
+        seen = 0
+        node.piece.length.times do |index|
+          next if bytes[node.piece.start + index] & 0xc0 == 0x80
+          return base + left_bytes + index if seen == within_piece
+          seen += 1
+        end
+      end
+
+      codepoint_offset(
+        node.right,
+        within_piece - node.piece.codepoints,
+        base + left_bytes + node.piece.length
+      )
+    end
+
+    private def count_newlines(source : Source, start : Int32, length : Int32) : Int32
+      count = 0
+      bytes = source.to_slice
+      length.times do |index|
+        byte = bytes[start + index]
+        next_byte_is_lf = index + 1 < length && bytes[start + index + 1] == '\n'.ord
+        count += 1 if byte == '\n'.ord || (byte == '\r'.ord && !next_byte_is_lf)
+      end
+      count
+    end
+
+    private def count_codepoints(source : Source, start : Int32, length : Int32) : Int32
+      count = 0
+      bytes = source.to_slice
+      length.times do |index|
+        count += 1 unless bytes[start + index] & 0xc0 == 0x80
+      end
+      count
+    end
+
+    private def validate_range(offset : Int32, length : Int32) : Nil
+      raise ArgumentError.new("length must not be negative") if length < 0
+      validate_boundary(offset)
+      finish = offset.to_i64 + length
+      raise ArgumentError.new("range outside buffer") if finish > byte_length
+      validate_boundary(finish.to_i32)
+    end
+
+    private def validate_boundary(offset : Int32) : Nil
+      raise ArgumentError.new("offset outside buffer") unless offset >= 0 && offset <= byte_length
+      return if offset == 0 || offset == byte_length
+
+      byte = byte_at(@root, offset)
+      raise ArgumentError.new("offset splits a UTF-8 codepoint") if byte & 0xc0 == 0x80
+      if byte == '\n'.ord && byte_at(@root, offset - 1) == '\r'.ord
+        raise ArgumentError.new("offset splits a CRLF line ending")
+      end
+    end
+
+    private def byte_at(node : Node?, offset : Int32) : UInt8
+      raise ArgumentError.new("offset outside buffer") unless node
+      left_bytes = self.class.node_bytes(node.left)
+      if offset < left_bytes
+        byte_at(node.left, offset)
+      elsif offset < left_bytes + node.piece.length
+        node.piece.source.to_slice[node.piece.start + offset - left_bytes]
+      else
+        byte_at(node.right, offset - left_bytes - node.piece.length)
+      end
+    end
+
+    private def validate_node!(node : Node?) : Tuple(Int32, Int32, Int32, Int32)
+      return {0, 0, 0, 0} unless node
+      source = node.piece.source
+      raise "empty piece persisted" if node.piece.length <= 0
+      finish = node.piece.start.to_i64 + node.piece.length
+      raise "piece range outside source" if node.piece.start < 0 || finish > source.to_slice.size
+      validate_source_boundary!(source, node.piece.start)
+      validate_source_boundary!(source, finish.to_i32)
+      expected_piece_newlines = count_newlines(source, node.piece.start, node.piece.length)
+      expected_piece_codepoints = count_codepoints(source, node.piece.start, node.piece.length)
+      raise "piece newline metric mismatch" unless expected_piece_newlines == node.piece.newlines
+      raise "piece codepoint metric mismatch" unless expected_piece_codepoints == node.piece.codepoints
+      raise "treap heap invariant violated" if node.left && node.left.not_nil!.priority > node.priority
+      raise "treap heap invariant violated" if node.right && node.right.not_nil!.priority > node.priority
+
+      left_bytes, left_newlines, left_count, left_height = validate_node!(node.left)
+      right_bytes, right_newlines, right_count, right_height = validate_node!(node.right)
+      expected_bytes = left_bytes + node.piece.length + right_bytes
+      expected_newlines = left_newlines + node.piece.newlines + right_newlines
+      expected_newlines -= 1 if node.left.try(&.ends_with_cr) && node.piece.starts_with_lf
+      expected_newlines -= 1 if node.piece.ends_with_cr && node.right.try(&.starts_with_lf)
+      expected_codepoints = self.class.node_codepoints(node.left) + node.piece.codepoints + self.class.node_codepoints(node.right)
+      expected_count = left_count + 1 + right_count
+      expected_height = 1 + Math.max(left_height, right_height)
+      expected_starts_with_lf = node.left ? node.left.not_nil!.starts_with_lf : node.piece.starts_with_lf
+      expected_ends_with_cr = node.right ? node.right.not_nil!.ends_with_cr : node.piece.ends_with_cr
+      raise "subtree byte metric mismatch" unless expected_bytes == node.byte_length
+      raise "subtree newline metric mismatch" unless expected_newlines == node.newline_count
+      raise "subtree codepoint metric mismatch" unless expected_codepoints == node.codepoint_count
+      raise "subtree piece metric mismatch" unless expected_count == node.piece_count
+      raise "subtree height metric mismatch" unless expected_height == node.height
+      raise "subtree first-byte metric mismatch" unless expected_starts_with_lf == node.starts_with_lf
+      raise "subtree last-byte metric mismatch" unless expected_ends_with_cr == node.ends_with_cr
+      raise "tree height bound violated" if expected_height > MAX_TREE_HEIGHT
+      {expected_bytes, expected_newlines, expected_count, expected_height}
+    end
+
+    private def validate_source_boundary!(source : Source, offset : Int32) : Nil
+      bytes = source.to_slice
+      return if offset == 0 || offset == bytes.size
+      raise "piece splits a UTF-8 codepoint" if bytes[offset] & 0xc0 == 0x80
+    end
+
+    private def roots_same?(left : Node?, right : Node?) : Bool
+      return true if left.nil? && right.nil?
+      return false if left.nil? || right.nil?
+      left.not_nil!.same?(right.not_nil!)
+    end
+  end
+end

--- a/src/tui/widgets/text_editor.cr
+++ b/src/tui/widgets/text_editor.cr
@@ -47,15 +47,35 @@ module Tui
     end
 
     struct EditState
-      getter text : String
+      getter snapshot : PieceTreeBuffer::Snapshot?
       getter line : Int32
       getter col : Int32
+      getter line_ending : String
+      @legacy_text : String?
 
-      def initialize(@text : String, @line : Int32, @col : Int32)
+      def initialize(snapshot : PieceTreeBuffer::Snapshot, @line : Int32, @col : Int32, @line_ending : String)
+        @snapshot = snapshot
+        @legacy_text = nil
+      end
+
+      # Compatibility constructor for callers that used EditState directly.
+      # TextEditor-created history entries always use structural snapshots.
+      def initialize(text : String, @line : Int32, @col : Int32)
+        @snapshot = nil
+        @line_ending = "\n"
+        @legacy_text = text
+      end
+
+      # Preserve the historical EditState API without retaining a duplicate
+      # document string in each undo entry.
+      def text : String
+        @legacy_text || @snapshot.not_nil!.text
       end
     end
 
-    @lines : Array(String) = [""]
+    @buffer : PieceTreeBuffer
+    @saved_snapshot : PieceTreeBuffer::Snapshot
+    @saved_line_ending : String = "\n"
     @cursor : Cursor = Cursor.new
     @selection : Selection?
     @scroll_x : Int32 = 0
@@ -71,7 +91,6 @@ module Tui
     @redo_stack : Array(EditState) = [] of EditState
     @last_edit_kind : Symbol? = nil
     @recording_undo : Bool = true
-    @saved_text : String = ""
     @line_ending : String = "\n"
 
     UNDO_LIMIT = 100
@@ -104,6 +123,8 @@ module Tui
 
     def initialize(id : String? = nil)
       super(id)
+      @buffer = PieceTreeBuffer.new
+      @saved_snapshot = @buffer.snapshot
       @focusable = true
       @v_scrollbar = ScrollBar.new(id ? "#{id}:v-scroll" : "text-editor:v-scroll", ScrollBar::Orientation::Vertical)
       @v_scrollbar.show_arrows = false
@@ -191,8 +212,8 @@ module Tui
     # True when `col` lands on the `{...}` after a collapsed header; expands the fold.
     def expand_fold_at_placeholder?(line : Int32, col : Int32) : Bool
       return false unless fold_placeholder_at(line)
-      return false if line < 0 || line >= @lines.size
-      start = @lines[line].size
+      return false if line < 0 || line >= line_count
+      start = line_length(line)
       return false unless col >= start && col < start + FOLD_PLACEHOLDER.size
       toggle_fold_at(line)
     end
@@ -207,7 +228,7 @@ module Tui
     end
 
     def scroll_view_by(lines : Int32) : Nil
-      return if lines == 0 || @lines.empty?
+      return if lines == 0 || line_count == 0
 
       offset = visible_index_of(@scroll_y) + lines
       apply_scrollbar_offset(offset)
@@ -229,8 +250,9 @@ module Tui
       @path
     end
 
+    # Returns a materialized snapshot. Mutate the editor through its edit API.
     def lines : Array(String)
-      @lines
+      Array.new(line_count) { |index| line_at(index) }
     end
 
     def cursor : Cursor
@@ -246,17 +268,17 @@ module Tui
     end
 
     def set_cursor(line : Int32, col : Int32) : Nil
-      return if @lines.empty?
+      return if line_count == 0
 
-      @cursor.line = line.clamp(0, @lines.size - 1)
-      @cursor.col = col.clamp(0, @lines[@cursor.line].size)
+      @cursor.line = line.clamp(0, line_count - 1)
+      @cursor.col = col.clamp(0, line_length(@cursor.line))
       @selection = nil
       ensure_cursor_visible
       mark_dirty!
     end
 
     def text : String
-      @lines.join(@line_ending)
+      @buffer.text
     end
 
     def text=(content : String) : Nil
@@ -282,15 +304,17 @@ module Tui
         @scroll_x = 0
         @scroll_y = 0
         @modified = false
-        @saved_text = text
+        @saved_snapshot = @buffer.snapshot
+        @saved_line_ending = @line_ending
         clear_undo_history
         clear_folds
         mark_dirty!
         true
       rescue ex
-        @lines = ["Error loading file:", ex.message || "Unknown error"]
+        load_content("Error loading file:\n#{ex.message || "Unknown error"}")
         @modified = false
-        @saved_text = text
+        @saved_snapshot = @buffer.snapshot
+        @saved_line_ending = @line_ending
         clear_undo_history
         clear_folds
         mark_dirty!
@@ -305,11 +329,12 @@ module Tui
 
     def save_as(path : Path) : Bool
       begin
-        atomic_write(path, text)
+        atomic_write(path) { |io| @buffer.write_to(io) }
         @path = path
         @title = path.basename
         @modified = false
-        @saved_text = text
+        @saved_snapshot = @buffer.snapshot
+        @saved_line_ending = @line_ending
         @on_save.try &.call(path)
         mark_dirty!
         true
@@ -318,7 +343,7 @@ module Tui
       end
     end
 
-    private def atomic_write(path : Path, content : String) : Nil
+    private def atomic_write(path : Path, & : IO ->) : Nil
       target = if File.info?(path, follow_symlinks: false).try(&.symlink?)
                  Path.new(File.realpath(path))
                else
@@ -331,7 +356,7 @@ module Tui
       renamed = false
 
       begin
-        temporary << content
+        yield temporary
         temporary.flush
         File.chmod(temporary_path, permissions) if permissions
         temporary.fsync
@@ -359,9 +384,10 @@ module Tui
       begin_edit(nil)
       line = @cursor.line
       col = @cursor.col
-      load_content(content)
-      @cursor.line = line.clamp(0, @lines.size - 1)
-      @cursor.col = col.clamp(0, @lines[@cursor.line].size)
+      @line_ending = detect_line_ending(content)
+      @buffer.replace_all(content)
+      @cursor.line = line.clamp(0, line_count - 1)
+      @cursor.col = col.clamp(0, line_length(@cursor.line))
       @selection = nil
       text_changed
       true
@@ -403,9 +429,11 @@ module Tui
         @last_edit_kind = :insert if has_sel
       end
       delete_selection(false) if @selection
-      line = @lines[@cursor.line]
-      @lines[@cursor.line] = line[0, @cursor.col] + char + line[@cursor.col..]
-      @cursor.col += 1
+      logical = normalize_newlines(char.to_s)
+      offset = byte_offset(@cursor.line, @cursor.col)
+      inserted = encode_newlines(logical, offset)
+      @buffer.insert(offset, inserted)
+      advance_cursor_by(logical)
       text_changed
     end
 
@@ -414,15 +442,20 @@ module Tui
 
       begin_edit(nil)
       delete_selection(false) if @selection
-      text.each_char { |c| insert_char(c, false) }
+      return if text.empty?
+
+      normalized = normalize_newlines(text)
+      offset = byte_offset(@cursor.line, @cursor.col)
+      @buffer.insert(offset, encode_newlines(normalized, offset))
+      advance_cursor_by(normalized)
+      text_changed
     end
 
     def insert_newline : Nil
       begin_edit(selection_active? ? nil : :newline)
       delete_selection(false) if @selection
-      line = @lines[@cursor.line]
-      @lines[@cursor.line] = line[0, @cursor.col]
-      @lines.insert(@cursor.line + 1, line[@cursor.col..])
+      offset = byte_offset(@cursor.line, @cursor.col)
+      @buffer.insert(offset, encode_newlines("\n", offset))
       @cursor.line += 1
       @cursor.col = 0
       text_changed
@@ -438,15 +471,19 @@ module Tui
 
       begin_edit(:backspace)
       if @cursor.col > 0
-        line = @lines[@cursor.line]
-        @lines[@cursor.line] = line[0, @cursor.col - 1] + line[@cursor.col..]
+        char = @buffer.character_at(@cursor.line, @cursor.col - 1).not_nil!
+        length = char.bytesize
+        offset = byte_offset(@cursor.line, @cursor.col) - length
+        delete_buffer_range(offset, length)
         @cursor.col -= 1
         text_changed
       elsif @cursor.line > 0
         # Join with previous line
-        prev_len = @lines[@cursor.line - 1].size
-        @lines[@cursor.line - 1] += @lines[@cursor.line]
-        @lines.delete_at(@cursor.line)
+        prev_line = @cursor.line - 1
+        prev_len = line_length(prev_line)
+        offset = byte_offset(prev_line, prev_len)
+        finish = @buffer.line_start_offset(@cursor.line)
+        delete_buffer_range(offset, finish - offset)
         @cursor.line -= 1
         @cursor.col = prev_len
         text_changed
@@ -459,17 +496,20 @@ module Tui
         return
       end
 
-      line = @lines[@cursor.line]
-      return if @cursor.col >= line.size && @cursor.line >= @lines.size - 1
+      length = line_length(@cursor.line)
+      return if @cursor.col >= length && @cursor.line >= line_count - 1
 
       begin_edit(:delete)
-      if @cursor.col < line.size
-        @lines[@cursor.line] = line[0, @cursor.col] + line[@cursor.col + 1..]
+      if @cursor.col < length
+        char = @buffer.character_at(@cursor.line, @cursor.col).not_nil!
+        offset = byte_offset(@cursor.line, @cursor.col)
+        delete_buffer_range(offset, char.bytesize)
         text_changed
-      elsif @cursor.line < @lines.size - 1
+      elsif @cursor.line < line_count - 1
         # Join with next line
-        @lines[@cursor.line] += @lines[@cursor.line + 1]
-        @lines.delete_at(@cursor.line + 1)
+        offset = byte_offset(@cursor.line, length)
+        finish = @buffer.line_start_offset(@cursor.line + 1)
+        delete_buffer_range(offset, finish - offset)
         text_changed
       end
     end
@@ -480,18 +520,9 @@ module Tui
 
       begin_edit(nil) if record_undo
       sel = sel.normalize
-      if sel.start_line == sel.end_line
-        line = @lines[sel.start_line]
-        @lines[sel.start_line] = line[0, sel.start_col] + line[sel.end_col..]
-      else
-        # Delete across lines
-        first_part = @lines[sel.start_line][0, sel.start_col]
-        last_part = @lines[sel.end_line][sel.end_col..]
-        @lines[sel.start_line] = first_part + last_part
-        (sel.end_line - sel.start_line).times do
-          @lines.delete_at(sel.start_line + 1)
-        end
-      end
+      start_offset = byte_offset(sel.start_line, sel.start_col)
+      end_offset = byte_offset(sel.end_line, sel.end_col)
+      delete_buffer_range(start_offset, end_offset - start_offset)
 
       @cursor.line = sel.start_line
       @cursor.col = sel.start_col
@@ -500,17 +531,17 @@ module Tui
     end
 
     def select_all : Nil
-      @selection = Selection.new(0, 0, @lines.size - 1, @lines.last.size)
+      @selection = Selection.new(0, 0, line_count - 1, line_length(line_count - 1))
       mark_dirty!
     end
 
     def select_range(start_line : Int32, start_col : Int32, end_line : Int32, end_col : Int32, *, cursor_at_end : Bool = true) : Nil
-      return if @lines.empty?
+      return if line_count == 0
 
-      start_line = start_line.clamp(0, @lines.size - 1)
-      end_line = end_line.clamp(0, @lines.size - 1)
-      start_col = start_col.clamp(0, @lines[start_line].size)
-      end_col = end_col.clamp(0, @lines[end_line].size)
+      start_line = start_line.clamp(0, line_count - 1)
+      end_line = end_line.clamp(0, line_count - 1)
+      start_col = start_col.clamp(0, line_length(start_line))
+      end_col = end_col.clamp(0, line_length(end_line))
       @selection = Selection.new(start_line, start_col, end_line, end_col)
       if cursor_at_end
         @cursor.line = end_line
@@ -528,16 +559,9 @@ module Tui
       return nil unless sel
 
       sel = sel.normalize
-      if sel.start_line == sel.end_line
-        @lines[sel.start_line][sel.start_col...sel.end_col]
-      else
-        result = @lines[sel.start_line][sel.start_col..]
-        (sel.start_line + 1...sel.end_line).each do |i|
-          result += "\n" + @lines[i]
-        end
-        result += "\n" + @lines[sel.end_line][0, sel.end_col]
-        result
-      end
+      start_offset = byte_offset(sel.start_line, sel.start_col)
+      end_offset = byte_offset(sel.end_line, sel.end_col)
+      normalize_newlines(@buffer.slice(start_offset, end_offset - start_offset))
     end
 
     def cut : String?
@@ -554,19 +578,9 @@ module Tui
       delete_selection(false) if @selection
       return if normalized.empty?
 
-      normalized.each_char do |char|
-        if char == '\n'
-          line = @lines[@cursor.line]
-          @lines[@cursor.line] = line[0, @cursor.col]
-          @lines.insert(@cursor.line + 1, line[@cursor.col..])
-          @cursor.line += 1
-          @cursor.col = 0
-        else
-          line = @lines[@cursor.line]
-          @lines[@cursor.line] = line[0, @cursor.col] + char + line[@cursor.col..]
-          @cursor.col += 1
-        end
-      end
+      offset = byte_offset(@cursor.line, @cursor.col)
+      @buffer.insert(offset, encode_newlines(normalized, offset))
+      advance_cursor_by(normalized)
 
       text_changed
     end
@@ -584,7 +598,7 @@ module Tui
         @cursor.col -= 1
       elsif @cursor.line > 0
         @cursor.line -= 1
-        @cursor.col = @lines[@cursor.line].size
+        @cursor.col = line_length(@cursor.line)
       end
 
       update_selection_end if with_selection
@@ -596,9 +610,9 @@ module Tui
       update_selection_start if with_selection && !@selection
       clear_selection unless with_selection
 
-      if @cursor.col < @lines[@cursor.line].size
+      if @cursor.col < line_length(@cursor.line)
         @cursor.col += 1
-      elsif @cursor.line < @lines.size - 1
+      elsif @cursor.line < line_count - 1
         @cursor.line += 1
         @cursor.col = 0
       end
@@ -615,7 +629,7 @@ module Tui
       target = previous_visible_line(@cursor.line)
       if target
         @cursor.line = target
-        @cursor.col = @cursor.col.clamp(0, @lines[@cursor.line].size)
+        @cursor.col = @cursor.col.clamp(0, line_length(@cursor.line))
       end
 
       update_selection_end if with_selection
@@ -630,7 +644,7 @@ module Tui
       target = next_visible_line(@cursor.line)
       if target
         @cursor.line = target
-        @cursor.col = @cursor.col.clamp(0, @lines[@cursor.line].size)
+        @cursor.col = @cursor.col.clamp(0, line_length(@cursor.line))
       end
 
       update_selection_end if with_selection
@@ -644,17 +658,9 @@ module Tui
 
       if @cursor.col == 0 && @cursor.line > 0
         @cursor.line -= 1
-        @cursor.col = @lines[@cursor.line].size
+        @cursor.col = line_length(@cursor.line)
       else
-        line = @lines[@cursor.line]
-        # Skip whitespace
-        while @cursor.col > 0 && line[@cursor.col - 1].whitespace?
-          @cursor.col -= 1
-        end
-        # Skip word chars
-        while @cursor.col > 0 && !line[@cursor.col - 1].whitespace?
-          @cursor.col -= 1
-        end
+        @cursor.col = @buffer.previous_word_column(@cursor.line, @cursor.col)
       end
 
       update_selection_end if with_selection
@@ -666,19 +672,12 @@ module Tui
       update_selection_start if with_selection && !@selection
       clear_selection unless with_selection
 
-      line = @lines[@cursor.line]
-      if @cursor.col >= line.size && @cursor.line < @lines.size - 1
+      length = line_length(@cursor.line)
+      if @cursor.col >= length && @cursor.line < line_count - 1
         @cursor.line += 1
         @cursor.col = 0
       else
-        # Skip word chars
-        while @cursor.col < line.size && !line[@cursor.col].whitespace?
-          @cursor.col += 1
-        end
-        # Skip whitespace
-        while @cursor.col < line.size && line[@cursor.col].whitespace?
-          @cursor.col += 1
-        end
+        @cursor.col = @buffer.next_word_column(@cursor.line, @cursor.col)
       end
 
       update_selection_end if with_selection
@@ -701,7 +700,7 @@ module Tui
       update_selection_start if with_selection && !@selection
       clear_selection unless with_selection
 
-      @cursor.col = @lines[@cursor.line].size
+      @cursor.col = line_length(@cursor.line)
 
       update_selection_end if with_selection
       ensure_cursor_visible
@@ -717,8 +716,8 @@ module Tui
     end
 
     def move_to_end : Nil
-      @cursor.line = @lines.size - 1
-      @cursor.col = @lines.last.size
+      @cursor.line = line_count - 1
+      @cursor.col = line_length(@cursor.line)
       @selection = nil
       ensure_cursor_visible
       mark_dirty!
@@ -733,7 +732,7 @@ module Tui
         line = previous
       end
       @cursor.line = line
-      @cursor.col = @cursor.col.clamp(0, @lines[@cursor.line].size)
+      @cursor.col = @cursor.col.clamp(0, line_length(@cursor.line))
       @selection = nil
       ensure_cursor_visible
       mark_dirty!
@@ -748,14 +747,14 @@ module Tui
         line = following
       end
       @cursor.line = line
-      @cursor.col = @cursor.col.clamp(0, @lines[@cursor.line].size)
+      @cursor.col = @cursor.col.clamp(0, line_length(@cursor.line))
       @selection = nil
       ensure_cursor_visible
       mark_dirty!
     end
 
     def goto_line(line : Int32) : Nil
-      @cursor.line = (line - 1).clamp(0, @lines.size - 1)
+      @cursor.line = (line - 1).clamp(0, line_count - 1)
       @cursor.col = 0
       @selection = nil
       ensure_cursor_visible
@@ -779,7 +778,7 @@ module Tui
     end
 
     private def current_edit_state : EditState
-      EditState.new(text, @cursor.line, @cursor.col)
+      EditState.new(@buffer.snapshot, @cursor.line, @cursor.col, @line_ending)
     end
 
     private def clear_undo_history : Nil
@@ -802,11 +801,16 @@ module Tui
 
     private def restore_edit_state(state : EditState) : Nil
       @recording_undo = false
-      load_content(state.text)
-      @cursor.line = state.line.clamp(0, @lines.size - 1)
-      @cursor.col = state.col.clamp(0, @lines[@cursor.line].size)
+      if snapshot = state.snapshot
+        @buffer.restore(snapshot)
+        @line_ending = state.line_ending
+      else
+        load_content(state.text)
+      end
+      @cursor.line = state.line.clamp(0, line_count - 1)
+      @cursor.col = state.col.clamp(0, line_length(@cursor.line))
       @selection = nil
-      @modified = text != @saved_text
+      @modified = !saved_state?
       clear_folds if @fold_ranges.any?
       @on_change.try &.call
       ensure_cursor_visible
@@ -817,8 +821,72 @@ module Tui
 
     private def load_content(content : String) : Nil
       @line_ending = detect_line_ending(content)
-      @lines = content.split(@line_ending, remove_empty: false)
-      @lines = [""] if @lines.empty?
+      @buffer.reset(content)
+    end
+
+    # TextEditor cursor columns are character indexes while PieceTreeBuffer
+    # edit offsets are UTF-8 byte indexes. Keep that conversion in one place.
+    private def line_count : Int32
+      @buffer.line_count
+    end
+
+    private def line_at(index : Int32) : String
+      @buffer.line(index)
+    end
+
+    private def line_length(index : Int32) : Int32
+      @buffer.line_character_length(index)
+    end
+
+    private def byte_offset(line : Int32, col : Int32) : Int32
+      start = @buffer.line_start_offset(line)
+      @buffer.byte_offset_at_codepoint(@buffer.codepoint_index_at_offset(start) + col)
+    end
+
+    private def encode_newlines(content : String, offset : Int32) : String
+      return content unless content.includes?('\n')
+
+      ending = @line_ending
+      previous_is_cr = offset > 0 && @buffer.byte_at_offset(offset - 1) == '\r'.ord
+      next_is_lf = @buffer.byte_at_offset(offset) == '\n'.ord
+      if (content.starts_with?("\n") && ending.starts_with?("\n") && previous_is_cr) ||
+         (content.ends_with?("\n") && ending.ends_with?("\r") && next_is_lf)
+        ending = "\r\n"
+      end
+      content.gsub("\n", ending)
+    end
+
+    # Deleting content between a lone CR and a lone LF must not silently merge
+    # two untouched logical line endings into one CRLF sequence.
+    private def delete_buffer_range(offset : Int32, length : Int32) : String
+      finish = offset + length
+      joins_crlf = offset > 0 && finish < @buffer.byte_length &&
+                   @buffer.byte_at_offset(offset - 1) == '\r'.ord &&
+                   @buffer.byte_at_offset(finish) == '\n'.ord
+      if joins_crlf
+        deleted = @buffer.slice(offset, length)
+        @buffer.delete(offset, length + 1)
+        replacement = @line_ending == "\n" ? "\n\n" : "\r\n"
+        @buffer.insert(offset, replacement)
+        deleted
+      else
+        @buffer.delete(offset, length)
+      end
+    end
+
+    private def advance_cursor_by(content : String) : Nil
+      content.each_char do |char|
+        if char == '\n'
+          @cursor.line += 1
+          @cursor.col = 0
+        else
+          @cursor.col += 1
+        end
+      end
+    end
+
+    private def saved_state? : Bool
+      @line_ending == @saved_line_ending && @buffer.same_state?(@saved_snapshot)
     end
 
     private def detect_line_ending(content : String) : String
@@ -848,7 +916,7 @@ module Tui
     end
 
     private def line_number_width : Int32
-      @show_line_numbers ? (@lines.size.to_s.size + 1) : 0
+      @show_line_numbers ? (line_count.to_s.size + 1) : 0
     end
 
     private def fold_gutter_width : Int32
@@ -877,16 +945,20 @@ module Tui
     end
 
     private def visible_line_count : Int32
+      return line_count if @collapsed_folds.empty?
+
       count = 0
-      @lines.size.times do |line|
+      line_count.times do |line|
         count += 1 unless line_hidden?(line)
       end
       count
     end
 
     private def visible_index_of(doc_line : Int32) : Int32
+      return doc_line.clamp(0, line_count) if @collapsed_folds.empty?
+
       index = 0
-      limit = doc_line.clamp(0, @lines.size)
+      limit = doc_line.clamp(0, line_count)
       limit.times do |line|
         index += 1 unless line_hidden?(line)
       end
@@ -894,10 +966,12 @@ module Tui
     end
 
     private def document_line_at_visible_index(visible_index : Int32) : Int32
-      return 0 if @lines.empty?
+      return 0 if line_count == 0
+      return visible_index.clamp(0, line_count - 1) if @collapsed_folds.empty?
+
       index = 0
       last_visible = 0
-      @lines.size.times do |line|
+      line_count.times do |line|
         next if line_hidden?(line)
         last_visible = line
         return line if index == visible_index
@@ -923,7 +997,7 @@ module Tui
     end
 
     private def rebuild_hidden_lines! : Nil
-      @hidden_lines = Array.new(@lines.size, false)
+      @hidden_lines = Array.new(line_count, false)
       @collapsed_folds.each do |start_line|
         range = @fold_starts[start_line]?
         next unless range
@@ -950,7 +1024,7 @@ module Tui
 
     private def next_visible_line(from : Int32) : Int32?
       line = from + 1
-      while line < @lines.size
+      while line < line_count
         return line unless line_hidden?(line)
         line += 1
       end
@@ -967,7 +1041,7 @@ module Tui
     end
 
     private def first_visible_from(from : Int32) : Int32
-      line = from.clamp(0, Math.max(@lines.size - 1, 0))
+      line = from.clamp(0, Math.max(line_count - 1, 0))
       return line unless line_hidden?(line)
       next_visible_line(line - 1) || previous_visible_line(line + 1) || 0
     end
@@ -986,7 +1060,7 @@ module Tui
 
     private def ensure_cursor_visible : Nil
       reveal_cursor_line!
-      return if @lines.empty?
+      return if line_count == 0
 
       # Vertical scrolling in document-line space, skipping hidden lines for height.
       if @cursor.line < @scroll_y || line_hidden?(@scroll_y)
@@ -1045,7 +1119,7 @@ module Tui
       visible_rows.times do |row|
         y = @rect.y + row
 
-        if doc_line >= @lines.size
+        if doc_line >= line_count
           @rect.width.times do |x|
             buffer.set(@rect.x + x, y, ' ', text_style) if clip.contains?(@rect.x + x, y)
           end
@@ -1069,10 +1143,15 @@ module Tui
           end
         end
 
-        line = @lines[doc_line]
+        full_length = line_length(doc_line)
+        visible_line = if @scroll_x <= full_length
+                         @buffer.line_slice(doc_line, @scroll_x, content_width)
+                       else
+                         ""
+                       end
         content_x = @rect.x + gutter_width
         placeholder = fold_placeholder_at(doc_line)
-        placeholder_start = line.size
+        placeholder_start = full_length
         line_placeholder_style = is_current_line && focused? ? Style.new(fg: @fold_placeholder_fg, bg: @current_line_bg) : placeholder_style
 
         content_width.times do |col|
@@ -1091,8 +1170,8 @@ module Tui
 
           char = if in_placeholder
                    placeholder_char
-                 elsif text_col < line.size
-                   c = line[text_col]
+                 elsif text_col < full_length
+                   c = visible_line[col]
                    c == '\t' ? ' ' : c
                  else
                    ' '
@@ -1296,11 +1375,11 @@ module Tui
         end
 
         text_x = rel_x - gutter_width + @scroll_x
-        if doc_line < @lines.size
+        if doc_line < line_count
           # iTerm2 SGR mouse reliably reports Shift; Ctrl is intercepted and
           # Option often does not set the Alt bit. Middle-click has no modifier.
           if hyperclick_mouse?(event)
-            col = text_x.clamp(0, @lines[doc_line].size)
+            col = text_x.clamp(0, line_length(doc_line))
             @cursor.line = doc_line
             @cursor.col = col
             @selection = nil
@@ -1313,7 +1392,7 @@ module Tui
             return true
           end
           @cursor.line = doc_line
-          @cursor.col = text_x.clamp(0, @lines[doc_line].size)
+          @cursor.col = text_x.clamp(0, line_length(doc_line))
           @selection = nil
           mark_dirty!
         end
@@ -1322,14 +1401,14 @@ module Tui
         focus unless focused?
         rel_x, rel_y = event.relative_to(@rect)
         text_x = rel_x - gutter_width + @scroll_x
-        text_y = document_line_at_visual_row(rel_y).clamp(0, @lines.size - 1)
+        text_y = document_line_at_visual_row(rel_y).clamp(0, line_count - 1)
 
         unless @selection
           @selection = Selection.new(@cursor.line, @cursor.col, @cursor.line, @cursor.col)
         end
 
         @cursor.line = text_y
-        @cursor.col = text_x.clamp(0, @lines[text_y].size)
+        @cursor.col = text_x.clamp(0, line_length(text_y))
         update_selection_end
 
         mark_dirty!


### PR DESCRIPTION
## Summary

- replace TextEditor line-array storage with a persistent UTF-8 piece tree
- share immutable roots across undo/redo states and stream saves without whole-document copies
- preserve LF, CRLF, CR, and mixed endings while keeping character-indexed cursor behavior
- bound long-line word navigation and viewport rendering to piece/range traversal

## Verification

- focused randomized buffer/editor suite: 36 examples, 0 failures (seed 89845)
- full crystal_tui suite: no failures beyond the pinned baseline; 636 examples with the existing 8 failures and 2 errors in unrelated Markdown/mouse specs
- Adamantine make check against this published revision: 339 examples, 0 failures
- 15 MiB / 100-snapshot release probe: 15.729 MiB retained source storage, 22.54 MiB peak RSS
- 200k-character word motion release probe: 0.82 ms

## Residual boundaries

Adamantine LSP full-document synchronization is a separate slice. Whole-document replacement retains both immutable sources while undoable; the rare height guard rebuild is O(piece_count).
