### PR TITLE
Emit structured text changes with cached UTF-16 positions

### DIFF
--- a/spec/tui/piece_tree_buffer_spec.cr
+++ b/spec/tui/piece_tree_buffer_spec.cr
@@ -127,15 +127,21 @@ describe Tui::PieceTreeBuffer do
     end
     buffer.line_character_length(0).should eq 3
     buffer.line_character_length(1).should eq 3 # combining mark is a codepoint
+    buffer.line_utf16_column(0, 0).should eq 0
+    buffer.line_utf16_column(0, 2).should eq 2
+    buffer.line_utf16_column(0, 3).should eq 4 # astral emoji uses two UTF-16 units
+    buffer.line_utf16_column(1, 3).should eq 3 # CJK and combining marks use one each
     buffer.line_slice(0, 1, 2).should eq "é🙂"
     buffer.character_at(1, 0).should eq '界'
     buffer.character_at(1, 3).should be_nil
+    expect_raises(ArgumentError) { buffer.line_utf16_column(0, 4) }
     expect_raises(ArgumentError) { buffer.byte_offset_at_codepoint(-1) }
     expect_raises(ArgumentError) { buffer.byte_offset_at_codepoint(boundaries.size) }
 
     crlf = Tui::PieceTreeBuffer.new("Aé🙂\r\n界é")
     crlf.line_character_length(0).should eq 3
     crlf.line_character_length(1).should eq 3
+    crlf.line_utf16_column(0, 3).should eq 4
   end
 
   it "rejects invalid ranges without changing the buffer" do

--- a/spec/tui/widgets/piece_tree_text_editor_spec.cr
+++ b/spec/tui/widgets/piece_tree_text_editor_spec.cr
@@ -9,6 +9,136 @@ private def piece_tree_editor(id : String, content : String = "") : Tui::TextEdi
 end
 
 describe Tui::TextEditor do
+  it "emits a bounded structured change with UTF-16 coordinates" do
+    editor = piece_tree_editor("piece-tree-change-unicode", "a🙂界\r\nnext")
+    changes = [] of Tui::TextEditor::TextChange
+    legacy_calls = 0
+    editor.on_text_change { |change| changes << change }
+    editor.on_change { legacy_calls += 1 }
+    editor.set_cursor(0, 2)
+
+    editor.insert_char('🚀')
+
+    changes.size.should eq 1
+    change = changes.first
+    change.incremental?.should be_true
+    change.start.should eq Tui::TextEditor::TextPosition.new(0, 2, 3)
+    change.finish.should eq Tui::TextEditor::TextPosition.new(0, 2, 3)
+    change.text.should eq "🚀"
+    legacy_calls.should eq 1
+  end
+
+  it "emits one replacement event for a multi-line selection" do
+    editor = piece_tree_editor("piece-tree-change-selection", "a🙂x\r\nnext")
+    changes = [] of Tui::TextEditor::TextChange
+    legacy_calls = 0
+    editor.on_text_change { |change| changes << change }
+    editor.on_change { legacy_calls += 1 }
+    editor.select_range(0, 1, 1, 2)
+
+    editor.insert_text("β\n")
+
+    editor.text.should eq "aβ\r\nxt"
+    changes.size.should eq 1
+    change = changes.first
+    change.start.should eq Tui::TextEditor::TextPosition.new(0, 1, 1)
+    change.finish.should eq Tui::TextEditor::TextPosition.new(1, 2, 2)
+    change.text.should eq "β\r\n"
+    legacy_calls.should eq 1
+  end
+
+  it "describes a CRLF line join using pre-edit coordinates" do
+    editor = piece_tree_editor("piece-tree-change-crlf", "a🙂\r\nb")
+    changes = [] of Tui::TextEditor::TextChange
+    editor.on_text_change { |change| changes << change }
+    editor.set_cursor(1, 0)
+
+    editor.backspace
+
+    editor.text.should eq "a🙂b"
+    change = changes.first
+    change.start.should eq Tui::TextEditor::TextPosition.new(0, 2, 3)
+    change.finish.should eq Tui::TextEditor::TextPosition.new(1, 0, 0)
+    change.text.should eq ""
+  end
+
+  it "describes delete, newline, and paste operations exactly" do
+    delete_editor = piece_tree_editor("piece-tree-change-delete", "a🙂b\r\nnext")
+    delete_changes = [] of Tui::TextEditor::TextChange
+    callback_text = ""
+    delete_editor.on_text_change do |change|
+      delete_changes << change
+      callback_text = delete_editor.text
+    end
+    delete_editor.set_cursor(0, 1)
+
+    delete_editor.delete
+
+    delete_changes.last.start.should eq Tui::TextEditor::TextPosition.new(0, 1, 1)
+    delete_changes.last.finish.should eq Tui::TextEditor::TextPosition.new(0, 2, 3)
+    delete_changes.last.text.should eq ""
+    callback_text.should eq "ab\r\nnext" # callback runs after mutation
+
+    newline_editor = piece_tree_editor("piece-tree-change-newline", "ab\rc")
+    newline_changes = [] of Tui::TextEditor::TextChange
+    newline_editor.on_text_change { |change| newline_changes << change }
+    newline_editor.set_cursor(0, 1)
+
+    newline_editor.insert_newline
+
+    newline_changes.last.start.should eq Tui::TextEditor::TextPosition.new(0, 1, 1)
+    newline_changes.last.finish.should eq Tui::TextEditor::TextPosition.new(0, 1, 1)
+    newline_changes.last.text.should eq "\r"
+    newline_editor.text.should eq "a\rb\rc"
+
+    paste_editor = piece_tree_editor("piece-tree-change-paste", "a\r\nb")
+    paste_changes = [] of Tui::TextEditor::TextChange
+    paste_editor.on_text_change { |change| paste_changes << change }
+    paste_editor.set_cursor(1, 1)
+
+    paste_editor.paste("x\ny")
+
+    paste_changes.last.start.should eq Tui::TextEditor::TextPosition.new(1, 1, 1)
+    paste_changes.last.finish.should eq Tui::TextEditor::TextPosition.new(1, 1, 1)
+    paste_changes.last.text.should eq "x\r\ny"
+    paste_editor.text.should eq "a\r\nbx\r\ny"
+  end
+
+  it "describes forward newline deletion as a cross-line range" do
+    editor = piece_tree_editor("piece-tree-change-delete-newline", "a\r\nb")
+    changes = [] of Tui::TextEditor::TextChange
+    editor.on_text_change { |change| changes << change }
+    editor.set_cursor(0, 1)
+
+    editor.delete
+
+    changes.last.start.should eq Tui::TextEditor::TextPosition.new(0, 1, 1)
+    changes.last.finish.should eq Tui::TextEditor::TextPosition.new(1, 0, 0)
+    changes.last.text.should eq ""
+    editor.text.should eq "ab"
+  end
+
+  it "uses full-change events when a precise local edit is unavailable" do
+    editor = piece_tree_editor("piece-tree-change-full", "a\rX\nb")
+    changes = [] of Tui::TextEditor::TextChange
+    editor.on_text_change { |change| changes << change }
+    editor.set_cursor(1, 1)
+
+    editor.backspace
+
+    editor.text.should eq "a\r\r\nb"
+    changes.last.full?.should be_true
+
+    editor.undo.should be_true
+    changes.last.full?.should be_true
+
+    editor.redo.should be_true
+    changes.last.full?.should be_true
+
+    editor.replace_text("replacement").should be_true
+    changes.last.full?.should be_true
+  end
+
   it "keeps cursor columns character-indexed across Unicode edits and undo" do
     editor = piece_tree_editor("piece-tree-unicode", "a🙂界\n終")
     editor.set_cursor(0, 2)

--- a/src/tui/text/piece_tree_buffer.cr
+++ b/src/tui/text/piece_tree_buffer.cr
@@ -18,6 +18,7 @@ module Tui
       getter length : Int32
       getter newlines : Int32
       getter codepoints : Int32
+      getter utf16_units : Int32
       getter starts_with_lf : Bool
       getter ends_with_cr : Bool
 
@@ -27,6 +28,7 @@ module Tui
         @length : Int32,
         @newlines : Int32,
         @codepoints : Int32,
+        @utf16_units : Int32,
         @starts_with_lf : Bool,
         @ends_with_cr : Bool,
       )
@@ -50,6 +52,7 @@ module Tui
       getter byte_length : Int32
       getter newline_count : Int32
       getter codepoint_count : Int32
+      getter utf16_unit_count : Int32
       getter piece_count : Int32
       getter height : Int32
       getter starts_with_lf : Bool
@@ -61,6 +64,7 @@ module Tui
         @newline_count -= 1 if @left.try(&.ends_with_cr) && @piece.starts_with_lf
         @newline_count -= 1 if @piece.ends_with_cr && @right.try(&.starts_with_lf)
         @codepoint_count = PieceTreeBuffer.node_codepoints(@left) + @piece.codepoints + PieceTreeBuffer.node_codepoints(@right)
+        @utf16_unit_count = PieceTreeBuffer.node_utf16_units(@left) + @piece.utf16_units + PieceTreeBuffer.node_utf16_units(@right)
         @piece_count = PieceTreeBuffer.node_count(@left) + 1 + PieceTreeBuffer.node_count(@right)
         @height = 1 + Math.max(PieceTreeBuffer.node_height(@left), PieceTreeBuffer.node_height(@right))
         @starts_with_lf = @left ? @left.not_nil!.starts_with_lf : @piece.starts_with_lf
@@ -159,6 +163,18 @@ module Tui
     def line_character_length(index : Int32) : Int32
       start, finish = line_content_range(index)
       codepoint_index_at_offset(finish) - codepoint_index_at_offset(start)
+    end
+
+    # Converts a character-indexed editor column to the UTF-16 code-unit
+    # coordinate used by LSP without materializing or scanning the line.
+    def line_utf16_column(index : Int32, column : Int32) : Int32
+      start, finish = line_content_range(index)
+      first_codepoint = codepoint_index_at_offset(start)
+      available = codepoint_index_at_offset(finish) - first_codepoint
+      raise ArgumentError.new("column outside line") unless column >= 0 && column <= available
+
+      target = byte_offset_at_codepoint(first_codepoint + column)
+      utf16_units_before_offset(target) - utf16_units_before_offset(start)
     end
 
     def line_slice(index : Int32, start_column : Int32, count : Int32) : String
@@ -377,6 +393,10 @@ module Tui
       node.try(&.codepoint_count) || 0
     end
 
+    protected def self.node_utf16_units(node : Node?) : Int32
+      node.try(&.utf16_unit_count) || 0
+    end
+
     protected def self.node_count(node : Node?) : Int32
       node.try(&.piece_count) || 0
     end
@@ -475,6 +495,7 @@ module Tui
         length,
         count_newlines(source, start, length),
         count_codepoints(source, start, length),
+        count_utf16_units(source, start, length),
         bytes[start] == '\n'.ord,
         bytes[start + length - 1] == '\r'.ord
       )
@@ -548,6 +569,7 @@ module Tui
           left_piece.length + right_piece.length,
           left_piece.newlines + right_piece.newlines - (left_piece.ends_with_cr && right_piece.starts_with_lf ? 1 : 0),
           left_piece.codepoints + right_piece.codepoints,
+          left_piece.utf16_units + right_piece.utf16_units,
           left_piece.starts_with_lf,
           right_piece.ends_with_cr
         )
@@ -804,6 +826,28 @@ module Tui
       count + count_codepoints_before(node.right, local - node.piece.length)
     end
 
+    private def utf16_units_before_offset(offset : Int32) : Int32
+      validate_boundary(offset)
+      count_utf16_units_before(@root, offset)
+    end
+
+    private def count_utf16_units_before(node : Node?, offset : Int32) : Int32
+      return 0 unless node
+
+      left_bytes = self.class.node_bytes(node.left)
+      if offset <= left_bytes
+        return count_utf16_units_before(node.left, offset)
+      end
+
+      count = self.class.node_utf16_units(node.left)
+      local = offset - left_bytes
+      take = Math.min(local, node.piece.length)
+      count += count_utf16_units(node.piece.source, node.piece.start, take)
+      return count if local <= node.piece.length
+
+      count + count_utf16_units_before(node.right, local - node.piece.length)
+    end
+
     private def codepoint_offset(node : Node?, ordinal : Int32, base : Int32) : Int32
       return base unless node
 
@@ -851,6 +895,18 @@ module Tui
       count
     end
 
+    private def count_utf16_units(source : Source, start : Int32, length : Int32) : Int32
+      count = 0
+      bytes = source.to_slice
+      length.times do |index|
+        byte = bytes[start + index]
+        next if byte & 0xc0 == 0x80
+
+        count += byte & 0xf8 == 0xf0 ? 2 : 1
+      end
+      count
+    end
+
     private def validate_range(offset : Int32, length : Int32) : Nil
       raise ArgumentError.new("length must not be negative") if length < 0
       validate_boundary(offset)
@@ -892,8 +948,10 @@ module Tui
       validate_source_boundary!(source, finish.to_i32)
       expected_piece_newlines = count_newlines(source, node.piece.start, node.piece.length)
       expected_piece_codepoints = count_codepoints(source, node.piece.start, node.piece.length)
+      expected_piece_utf16_units = count_utf16_units(source, node.piece.start, node.piece.length)
       raise "piece newline metric mismatch" unless expected_piece_newlines == node.piece.newlines
       raise "piece codepoint metric mismatch" unless expected_piece_codepoints == node.piece.codepoints
+      raise "piece UTF-16 metric mismatch" unless expected_piece_utf16_units == node.piece.utf16_units
       raise "treap heap invariant violated" if node.left && node.left.not_nil!.priority > node.priority
       raise "treap heap invariant violated" if node.right && node.right.not_nil!.priority > node.priority
 
@@ -904,6 +962,7 @@ module Tui
       expected_newlines -= 1 if node.left.try(&.ends_with_cr) && node.piece.starts_with_lf
       expected_newlines -= 1 if node.piece.ends_with_cr && node.right.try(&.starts_with_lf)
       expected_codepoints = self.class.node_codepoints(node.left) + node.piece.codepoints + self.class.node_codepoints(node.right)
+      expected_utf16_units = self.class.node_utf16_units(node.left) + node.piece.utf16_units + self.class.node_utf16_units(node.right)
       expected_count = left_count + 1 + right_count
       expected_height = 1 + Math.max(left_height, right_height)
       expected_starts_with_lf = node.left ? node.left.not_nil!.starts_with_lf : node.piece.starts_with_lf
@@ -911,6 +970,7 @@ module Tui
       raise "subtree byte metric mismatch" unless expected_bytes == node.byte_length
       raise "subtree newline metric mismatch" unless expected_newlines == node.newline_count
       raise "subtree codepoint metric mismatch" unless expected_codepoints == node.codepoint_count
+      raise "subtree UTF-16 metric mismatch" unless expected_utf16_units == node.utf16_unit_count
       raise "subtree piece metric mismatch" unless expected_count == node.piece_count
       raise "subtree height metric mismatch" unless expected_height == node.height
       raise "subtree first-byte metric mismatch" unless expected_starts_with_lf == node.starts_with_lf

--- a/src/tui/widgets/text_editor.cr
+++ b/src/tui/widgets/text_editor.cr
@@ -33,6 +33,45 @@ module Tui
       end
     end
 
+    # A position in both the editor's public character coordinates and UTF-16
+    # coordinates suitable for protocol boundaries such as LSP.
+    struct TextPosition
+      getter line : Int32
+      getter column : Int32
+      getter utf16_column : Int32
+
+      def initialize(@line : Int32, @column : Int32, @utf16_column : Int32)
+      end
+    end
+
+    # Describes one logical mutation. Incremental ranges refer to the document
+    # before the mutation and +text+ is the exact replacement stored afterward.
+    # Full changes deliberately omit text so consumers materialize it only when
+    # their compatibility boundary requires a complete document.
+    struct TextChange
+      getter start : TextPosition?
+      getter finish : TextPosition?
+      getter text : String
+
+      def initialize(@start : TextPosition, @finish : TextPosition, @text : String)
+      end
+
+      private def initialize(@start : Nil, @finish : Nil, @text : String)
+      end
+
+      def self.full : TextChange
+        new(nil, nil, "")
+      end
+
+      def incremental? : Bool
+        !@start.nil?
+      end
+
+      def full? : Bool
+        !incremental?
+      end
+    end
+
     # LSP-style fold: start_line stays visible; start_line+1..end_line hide when collapsed.
     struct FoldRange
       property start_line : Int32
@@ -116,6 +155,7 @@ module Tui
 
     # Callbacks
     @on_change : Proc(Nil)?
+    @on_text_change : Proc(TextChange, Nil)?
     @on_save : Proc(Path, Nil)?
     @on_cell_style : Proc(Int32, Int32, Char, Style, Style)?
     @on_hyperclick : Proc(Int32, Int32, Modifiers, Nil)?
@@ -133,6 +173,10 @@ module Tui
 
     def on_change(&block : -> Nil) : Nil
       @on_change = block
+    end
+
+    def on_text_change(&block : TextChange -> Nil) : Nil
+      @on_text_change = block
     end
 
     def on_save(&block : Path -> Nil) : Nil
@@ -389,7 +433,7 @@ module Tui
       @cursor.line = line.clamp(0, line_count - 1)
       @cursor.col = col.clamp(0, line_length(@cursor.line))
       @selection = nil
-      text_changed
+      text_changed(TextChange.full)
       true
     end
 
@@ -428,37 +472,51 @@ module Tui
         begin_edit(has_sel ? nil : :insert)
         @last_edit_kind = :insert if has_sel
       end
-      delete_selection(false) if @selection
+      selection_change = delete_selection_content(false) if @selection
+      start_position = selection_change.try(&.[0]) || current_text_position
+      finish_position = selection_change.try(&.[1]) || start_position
+      exact = selection_change.try(&.[2]) != false
       logical = normalize_newlines(char.to_s)
       offset = byte_offset(@cursor.line, @cursor.col)
       inserted = encode_newlines(logical, offset)
       @buffer.insert(offset, inserted)
       advance_cursor_by(logical)
-      text_changed
+      text_changed(exact ? TextChange.new(start_position, finish_position, inserted) : TextChange.full)
     end
 
     def insert_text(text : String) : Nil
       return if text.empty? && @selection.nil?
 
       begin_edit(nil)
-      delete_selection(false) if @selection
-      return if text.empty?
+      selection_change = delete_selection_content(false) if @selection
+      start_position = selection_change.try(&.[0]) || current_text_position
+      finish_position = selection_change.try(&.[1]) || start_position
+      exact = selection_change.try(&.[2]) != false
+      if text.empty?
+        text_changed(exact ? TextChange.new(start_position, finish_position, "") : TextChange.full)
+        return
+      end
 
       normalized = normalize_newlines(text)
       offset = byte_offset(@cursor.line, @cursor.col)
-      @buffer.insert(offset, encode_newlines(normalized, offset))
+      inserted = encode_newlines(normalized, offset)
+      @buffer.insert(offset, inserted)
       advance_cursor_by(normalized)
-      text_changed
+      text_changed(exact ? TextChange.new(start_position, finish_position, inserted) : TextChange.full)
     end
 
     def insert_newline : Nil
       begin_edit(selection_active? ? nil : :newline)
-      delete_selection(false) if @selection
+      selection_change = delete_selection_content(false) if @selection
+      start_position = selection_change.try(&.[0]) || current_text_position
+      finish_position = selection_change.try(&.[1]) || start_position
+      exact = selection_change.try(&.[2]) != false
       offset = byte_offset(@cursor.line, @cursor.col)
-      @buffer.insert(offset, encode_newlines("\n", offset))
+      inserted = encode_newlines("\n", offset)
+      @buffer.insert(offset, inserted)
       @cursor.line += 1
       @cursor.col = 0
-      text_changed
+      text_changed(exact ? TextChange.new(start_position, finish_position, inserted) : TextChange.full)
     end
 
     def backspace : Nil
@@ -471,22 +529,26 @@ module Tui
 
       begin_edit(:backspace)
       if @cursor.col > 0
+        finish_position = current_text_position
+        start_position = text_position(@cursor.line, @cursor.col - 1)
         char = @buffer.character_at(@cursor.line, @cursor.col - 1).not_nil!
         length = char.bytesize
         offset = byte_offset(@cursor.line, @cursor.col) - length
-        delete_buffer_range(offset, length)
+        exact = delete_buffer_range(offset, length)
         @cursor.col -= 1
-        text_changed
+        text_changed(exact ? TextChange.new(start_position, finish_position, "") : TextChange.full)
       elsif @cursor.line > 0
         # Join with previous line
+        finish_position = current_text_position
         prev_line = @cursor.line - 1
         prev_len = line_length(prev_line)
+        start_position = text_position(prev_line, prev_len)
         offset = byte_offset(prev_line, prev_len)
         finish = @buffer.line_start_offset(@cursor.line)
-        delete_buffer_range(offset, finish - offset)
+        exact = delete_buffer_range(offset, finish - offset)
         @cursor.line -= 1
         @cursor.col = prev_len
-        text_changed
+        text_changed(exact ? TextChange.new(start_position, finish_position, "") : TextChange.full)
       end
     end
 
@@ -501,33 +563,28 @@ module Tui
 
       begin_edit(:delete)
       if @cursor.col < length
+        start_position = current_text_position
+        finish_position = text_position(@cursor.line, @cursor.col + 1)
         char = @buffer.character_at(@cursor.line, @cursor.col).not_nil!
         offset = byte_offset(@cursor.line, @cursor.col)
-        delete_buffer_range(offset, char.bytesize)
-        text_changed
+        exact = delete_buffer_range(offset, char.bytesize)
+        text_changed(exact ? TextChange.new(start_position, finish_position, "") : TextChange.full)
       elsif @cursor.line < line_count - 1
         # Join with next line
+        start_position = current_text_position
+        finish_position = text_position(@cursor.line + 1, 0)
         offset = byte_offset(@cursor.line, length)
         finish = @buffer.line_start_offset(@cursor.line + 1)
-        delete_buffer_range(offset, finish - offset)
-        text_changed
+        exact = delete_buffer_range(offset, finish - offset)
+        text_changed(exact ? TextChange.new(start_position, finish_position, "") : TextChange.full)
       end
     end
 
     def delete_selection(record_undo : Bool = true) : Nil
-      sel = @selection
-      return unless sel
+      change = delete_selection_content(record_undo)
+      return unless change
 
-      begin_edit(nil) if record_undo
-      sel = sel.normalize
-      start_offset = byte_offset(sel.start_line, sel.start_col)
-      end_offset = byte_offset(sel.end_line, sel.end_col)
-      delete_buffer_range(start_offset, end_offset - start_offset)
-
-      @cursor.line = sel.start_line
-      @cursor.col = sel.start_col
-      @selection = nil
-      text_changed
+      text_changed(change[2] ? TextChange.new(change[0], change[1], "") : TextChange.full)
     end
 
     def select_all : Nil
@@ -575,14 +632,21 @@ module Tui
       return if normalized.empty? && @selection.nil?
 
       begin_edit(nil)
-      delete_selection(false) if @selection
-      return if normalized.empty?
+      selection_change = delete_selection_content(false) if @selection
+      start_position = selection_change.try(&.[0]) || current_text_position
+      finish_position = selection_change.try(&.[1]) || start_position
+      exact = selection_change.try(&.[2]) != false
+      if normalized.empty?
+        text_changed(exact ? TextChange.new(start_position, finish_position, "") : TextChange.full)
+        return
+      end
 
       offset = byte_offset(@cursor.line, @cursor.col)
-      @buffer.insert(offset, encode_newlines(normalized, offset))
+      inserted = encode_newlines(normalized, offset)
+      @buffer.insert(offset, inserted)
       advance_cursor_by(normalized)
 
-      text_changed
+      text_changed(exact ? TextChange.new(start_position, finish_position, inserted) : TextChange.full)
     end
 
     private def normalize_newlines(text : String) : String
@@ -761,9 +825,14 @@ module Tui
       mark_dirty!
     end
 
-    private def text_changed : Nil
+    private def text_changed(change : TextChange) : Nil
       @modified = true
       clear_folds if @fold_ranges.any?
+      notify_text_change(change)
+    end
+
+    private def notify_text_change(change : TextChange) : Nil
+      @on_text_change.try &.call(change)
       @on_change.try &.call
       ensure_cursor_visible
       mark_dirty!
@@ -812,9 +881,7 @@ module Tui
       @selection = nil
       @modified = !saved_state?
       clear_folds if @fold_ranges.any?
-      @on_change.try &.call
-      ensure_cursor_visible
-      mark_dirty!
+      notify_text_change(TextChange.full)
     ensure
       @recording_undo = true
     end
@@ -843,6 +910,32 @@ module Tui
       @buffer.byte_offset_at_codepoint(@buffer.codepoint_index_at_offset(start) + col)
     end
 
+    private def text_position(line : Int32, col : Int32) : TextPosition
+      TextPosition.new(line, col, @buffer.line_utf16_column(line, col))
+    end
+
+    private def current_text_position : TextPosition
+      text_position(@cursor.line, @cursor.col)
+    end
+
+    private def delete_selection_content(record_undo : Bool) : Tuple(TextPosition, TextPosition, Bool)?
+      sel = @selection
+      return nil unless sel
+
+      begin_edit(nil) if record_undo
+      sel = sel.normalize
+      start_position = text_position(sel.start_line, sel.start_col)
+      finish_position = text_position(sel.end_line, sel.end_col)
+      start_offset = byte_offset(sel.start_line, sel.start_col)
+      end_offset = byte_offset(sel.end_line, sel.end_col)
+      exact = delete_buffer_range(start_offset, end_offset - start_offset)
+
+      @cursor.line = sel.start_line
+      @cursor.col = sel.start_col
+      @selection = nil
+      {start_position, finish_position, exact}
+    end
+
     private def encode_newlines(content : String, offset : Int32) : String
       return content unless content.includes?('\n')
 
@@ -858,19 +951,19 @@ module Tui
 
     # Deleting content between a lone CR and a lone LF must not silently merge
     # two untouched logical line endings into one CRLF sequence.
-    private def delete_buffer_range(offset : Int32, length : Int32) : String
+    private def delete_buffer_range(offset : Int32, length : Int32) : Bool
       finish = offset + length
       joins_crlf = offset > 0 && finish < @buffer.byte_length &&
                    @buffer.byte_at_offset(offset - 1) == '\r'.ord &&
                    @buffer.byte_at_offset(finish) == '\n'.ord
       if joins_crlf
-        deleted = @buffer.slice(offset, length)
         @buffer.delete(offset, length + 1)
         replacement = @line_ending == "\n" ? "\n\n" : "\r\n"
         @buffer.insert(offset, replacement)
-        deleted
+        false
       else
         @buffer.delete(offset, length)
+        true
       end
     end
 


### PR DESCRIPTION
## Summary

- add structured TextEditor change events with pre-edit ranges and exact replacement text
- cache UTF-16 metrics in the piece tree for bounded-cost LSP position conversion
- retain legacy callbacks and use full-change events for coarse operations and recovery paths
- collapse selection replacement into one logical notification

## Verification

- focused structured-change and UTF-16 suite: 26 examples, 0 failures
- full suite: 644 examples, with the same four pre-existing mouse-spec failures as the 638-example clean main baseline
- 8,000,000-character single-line benchmark: ten one-byte edits reduced from 405.74 ms to 0.24 ms in release mode