### PR TITLE
feat(text-editor): add guarded external reload primitives

### DIFF
--- a/spec/tui/widgets/text_editor_external_reload_spec.cr
+++ b/spec/tui/widgets/text_editor_external_reload_spec.cr
@@ -1,0 +1,209 @@
+require "../../spec_helper"
+require "file_utils"
+
+private def external_reload_editor(id : String, content : String = "") : Tui::TextEditor
+  editor = Tui::TextEditor.new(id)
+  editor.rect = Tui::Rect.new(0, 0, 40, 10)
+  editor.text = content unless content.empty?
+  editor.focus
+  editor
+end
+
+private def with_external_reload_file(content : String, &)
+  root = Path.new(Dir.tempdir, "text-editor-external-reload-#{Random::Secure.hex(8)}")
+  Dir.mkdir_p(root)
+  path = root / "sample.txt"
+  File.write(path.to_s, content)
+  begin
+    yield root, path
+  ensure
+    FileUtils.rm_rf(root.to_s)
+  end
+end
+
+describe Tui::TextEditor do
+  it "reloads external content as clean while retaining OURS as one undo entry" do
+    with_external_reload_file("base\nline\n") do |_root, path|
+      editor = external_reload_editor("external-reload-history")
+      editor.load_file(path).should be_true
+      editor.set_cursor(1, 2)
+      editor.insert_char('!')
+      editor.insert_text("?")
+      editor.undo.should be_true
+      editor.text.should eq "base\nli!ne\n"
+      editor.set_fold_ranges([Tui::TextEditor::FoldRange.new(0, 1)])
+      editor.toggle_fold_at(0).should be_true
+      editor.can_redo?.should be_true
+
+      changes = [] of Tui::TextEditor::TextChange
+      editor.on_text_change { |change| changes << change }
+
+      editor.reload_as_saved("external\nchanged").should be_true
+
+      editor.text.should eq "external\nchanged"
+      editor.modified?.should be_false
+      editor.path.should eq path
+      editor.title.should eq path.basename
+      editor.cursor.should eq Tui::TextEditor::Cursor.new(1, 3)
+      editor.fold_ranges.should be_empty
+      editor.can_undo?.should be_true
+      editor.can_redo?.should be_false
+      changes.size.should eq 1
+      changes.first.full?.should be_true
+
+      editor.undo.should be_true
+      editor.text.should eq "base\nli!ne\n"
+      editor.modified?.should be_true
+      changes.size.should eq 2
+      changes.last.full?.should be_true
+
+      editor.redo.should be_true
+      editor.text.should eq "external\nchanged"
+      editor.modified?.should be_false
+      changes.size.should eq 3
+      changes.last.full?.should be_true
+    end
+  end
+
+  it "loads exact content as a clean baseline and reuses the optional path" do
+    path = Path.new(Dir.tempdir, "text-editor-content-as-saved-#{Random::Secure.hex(8)}.txt")
+    editor = external_reload_editor("content-as-saved")
+
+    editor.load_content_as_saved("first\r\nsecond", path).should be_true
+    editor.text.should eq "first\r\nsecond"
+    editor.modified?.should be_false
+    editor.path.should eq path
+    editor.title.should eq path.basename
+    editor.cursor.should eq Tui::TextEditor::Cursor.new(0, 0)
+    editor.can_undo?.should be_false
+
+    editor.set_cursor(1, 4)
+    editor.reload_as_saved("new\ncontent").should be_true
+    editor.path.should eq path
+    editor.title.should eq path.basename
+    editor.cursor.should eq Tui::TextEditor::Cursor.new(1, 4)
+    editor.modified?.should be_false
+  end
+
+  it "accepts identical current bytes without creating a duplicate undo state" do
+    editor = external_reload_editor("accept-current")
+    editor.load_content_as_saved("same\n", Path.new("same.txt")).should be_true
+
+    editor.accept_current_as_saved.should be_true
+
+    editor.text.should eq "same\n"
+    editor.modified?.should be_false
+    editor.can_undo?.should be_false
+  end
+
+  it "streams exact piece-tree bytes with the detected line ending" do
+    editor = external_reload_editor("streaming")
+    editor.load_content_as_saved("first\r\nsecond", Path.new("streaming.txt")).should be_true
+    editor.set_cursor(0, 5)
+    editor.insert_newline
+
+    output = IO::Memory.new
+    editor.write_to(output).should eq output.to_s.bytesize
+    output.to_s.should eq "first\r\n\r\nsecond"
+  end
+
+  it "retains only the immediately previous root across repeated external reloads" do
+    editor = external_reload_editor("reload-ours")
+
+    101.times do |index|
+      editor.reload_as_saved("reload-#{index}").should be_true
+    end
+
+    editor.undo.should be_true
+    editor.text.should eq "reload-99"
+    editor.undo.should be_false
+  end
+
+  it "rejects a checked save before rename and reports the resolved target" do
+    with_external_reload_file("disk") do |root, path|
+      target = root / "target.txt"
+      link = root / "link.txt"
+      File.rename(path, target)
+      File.symlink(target.basename.to_s, link)
+
+      editor = external_reload_editor("checked-save-reject")
+      editor.load_file(link).should be_true
+      editor.insert_text("ours")
+      before_path = editor.path
+      before_text = editor.text
+      before_title = editor.title
+      save_callbacks = [] of Path
+      editor.on_save { |saved_path| save_callbacks << saved_path }
+      guard_paths = [] of Path
+      observed_disk = ""
+
+      editor.save_as_checked(link) do |resolved_path|
+        guard_paths << resolved_path
+        observed_disk = File.read(resolved_path.to_s)
+        false
+      end.should be_false
+
+      guard_paths.should eq [Path.new(File.realpath(link))]
+      observed_disk.should eq "disk"
+      File.read(target.to_s).should eq "disk"
+      editor.text.should eq before_text
+      editor.path.should eq before_path
+      editor.title.should eq before_title
+      editor.modified?.should be_true
+      save_callbacks.should be_empty
+    end
+  end
+
+  it "preserves the logical path in on_save after a checked save" do
+    with_external_reload_file("disk") do |root, path|
+      target = root / "target.txt"
+      link = root / "link.txt"
+      File.rename(path, target)
+      File.symlink(target.basename.to_s, link)
+
+      editor = external_reload_editor("checked-save-success")
+      editor.load_file(link).should be_true
+      editor.insert_text("ours")
+      saved_paths = [] of Path
+      editor.on_save { |saved_path| saved_paths << saved_path }
+
+      editor.save_checked { |resolved_path| resolved_path == Path.new(File.realpath(link)) }.should be_true
+
+      File.read(target.to_s).should eq editor.text
+      editor.path.should eq link
+      saved_paths.should eq [link]
+      editor.modified?.should be_false
+    end
+  end
+
+  it "stays dirty and suppresses callbacks when post-rename validation fails" do
+    with_external_reload_file("disk") do |_root, path|
+      editor = external_reload_editor("checked-save-post-reject")
+      editor.load_file(path).should be_true
+      editor.insert_text("ours")
+      saved_paths = [] of Path
+      editor.on_save { |saved_path| saved_paths << saved_path }
+      before_paths = [] of Path
+      after_paths = [] of Path
+
+      before_rename = ->(resolved_path : Path) do
+        before_paths << resolved_path
+        true
+      end
+      after_rename = ->(resolved_path : Path) do
+        after_paths << resolved_path
+        File.write(resolved_path.to_s, "external-after-rename")
+        false
+      end
+
+      editor.save_checked(before_rename, after_rename).should be_false
+
+      resolved = path.expand
+      before_paths.should eq [resolved]
+      after_paths.should eq [resolved]
+      File.read(path.to_s).should eq "external-after-rename"
+      editor.modified?.should be_true
+      saved_paths.should be_empty
+    end
+  end
+end

--- a/src/tui/widgets/text_editor.cr
+++ b/src/tui/widgets/text_editor.cr
@@ -325,6 +325,11 @@ module Tui
       @buffer.text
     end
 
+    # Stream the current document bytes directly from the piece tree.
+    def write_to(io : IO) : Int32
+      @buffer.write_to(io)
+    end
+
     def text=(content : String) : Nil
       load_content(content)
       @cursor = Cursor.new
@@ -340,19 +345,7 @@ module Tui
     def load_file(path : Path) : Bool
       begin
         content = File.read(path.to_s)
-        load_content(content)
-        @path = path
-        @title = path.basename
-        @cursor = Cursor.new
-        @selection = nil
-        @scroll_x = 0
-        @scroll_y = 0
-        @modified = false
-        @saved_snapshot = @buffer.snapshot
-        @saved_line_ending = @line_ending
-        clear_undo_history
-        clear_folds
-        mark_dirty!
+        apply_content_as_saved(content, path, preserve_history: false, notify: false)
         true
       rescue ex
         load_content("Error loading file:\n#{ex.message || "Unknown error"}")
@@ -366,14 +359,72 @@ module Tui
       end
     end
 
+    # Load exact content as the saved baseline. By default this is an initial
+    # load and clears history; callers accepting an external revision should
+    # use `reload_as_saved`, which preserves the current structural root.
+    def load_content_as_saved(content : String, path : Path? = nil, *, preserve_history : Bool = false) : Bool
+      apply_content_as_saved(content, path, preserve_history: preserve_history, notify: true)
+    end
+
+    # Accept externally reloaded content as the clean baseline while retaining
+    # the current piece-tree root as one undoable history entry.
+    def reload_as_saved(content : String, path : Path? = nil) : Bool
+      load_content_as_saved(content, path, preserve_history: true)
+    end
+
+    # Accept the existing piece-tree root as the saved baseline. This is used
+    # when an independently validated disk revision has identical bytes, so a
+    # no-op reload does not create a dirty undo entry containing the same text.
+    def accept_current_as_saved(path : Path? = nil) : Bool
+      if path
+        @path = path
+        @title = path.basename
+      end
+      @modified = false
+      @saved_snapshot = @buffer.snapshot
+      @saved_line_ending = @line_ending
+      mark_dirty!
+      true
+    end
+
     def save : Bool
       return false unless path = @path
       save_as(path)
     end
 
+    # Save the active path after the caller approves the resolved target just
+    # before the temporary file is renamed into place.
+    def save_checked(&guard : Path -> Bool) : Bool
+      return false unless path = @path
+      save_as_checked(path, &guard)
+    end
+
+    # Save the active path with validation immediately before and after the
+    # atomic replacement. The editor becomes clean only after both predicates
+    # accept the resolved physical target.
+    def save_checked(before_rename : Proc(Path, Bool), after_rename : Proc(Path, Bool)) : Bool
+      return false unless path = @path
+      save_as_checked(path, before_rename, after_rename)
+    end
+
     def save_as(path : Path) : Bool
+      save_as_checked(path) { |_target| true }
+    end
+
+    # Save +path+ with a final, pre-rename predicate. A false predicate leaves
+    # the target and editor state untouched.
+    def save_as_checked(path : Path, &guard : Path -> Bool) : Bool
+      save_as_checked(path, guard, ->(_target : Path) { true })
+    end
+
+    # Save +path+ with predicates around the atomic replacement. A failed
+    # pre-rename predicate leaves the target untouched; a failed post-rename
+    # predicate leaves the editor dirty and suppresses the save callback.
+    def save_as_checked(path : Path, before_rename : Proc(Path, Bool), after_rename : Proc(Path, Bool)) : Bool
       begin
-        atomic_write(path) { |io| @buffer.write_to(io) }
+        target = atomic_write(path, before_rename) { |io| @buffer.write_to(io) }
+        return false unless target
+        return false unless after_rename.call(target)
         @path = path
         @title = path.basename
         @modified = false
@@ -387,7 +438,7 @@ module Tui
       end
     end
 
-    private def atomic_write(path : Path, & : IO ->) : Nil
+    private def atomic_write(path : Path, guard : Proc(Path, Bool), & : IO ->) : Path?
       target = if File.info?(path, follow_symlinks: false).try(&.symlink?)
                  Path.new(File.realpath(path))
                else
@@ -405,6 +456,7 @@ module Tui
         File.chmod(temporary_path, permissions) if permissions
         temporary.fsync
         temporary.close
+        return nil unless guard.call(target)
         File.rename(temporary_path, target)
         renamed = true
 
@@ -414,6 +466,7 @@ module Tui
           # Some platforms do not permit opening directories. The file itself
           # is already durable and atomically visible at this point.
         end
+        target
       ensure
         temporary.close unless temporary.closed?
         File.delete(temporary_path) if !renamed && File.exists?(temporary_path)
@@ -889,6 +942,48 @@ module Tui
     private def load_content(content : String) : Nil
       @line_ending = detect_line_ending(content)
       @buffer.reset(content)
+    end
+
+    private def apply_content_as_saved(content : String, path : Path?, *, preserve_history : Bool, notify : Bool) : Bool
+      raise ArgumentError.new("buffer text must be valid UTF-8") unless content.valid_encoding?
+
+      if preserve_history
+        old_line = @cursor.line
+        old_col = @cursor.col
+        # External revisions can contain megabytes of new source bytes. Keep
+        # exactly the current editor root as OURS so repeated reloads cannot
+        # retain an unbounded chain of complete external revisions.
+        clear_undo_history
+        begin_edit(nil)
+        @line_ending = detect_line_ending(content)
+        @buffer.replace_all(content)
+        @cursor.line = old_line.clamp(0, line_count - 1)
+        @cursor.col = old_col.clamp(0, line_length(@cursor.line))
+        @selection = nil
+      else
+        load_content(content)
+        @cursor = Cursor.new
+        @selection = nil
+        @scroll_x = 0
+        @scroll_y = 0
+        clear_undo_history
+      end
+
+      if path
+        @path = path
+        @title = path.basename
+      end
+      @modified = false
+      @saved_snapshot = @buffer.snapshot
+      @saved_line_ending = @line_ending
+      clear_folds
+      ensure_cursor_visible
+      if notify
+        notify_text_change(TextChange.full)
+      else
+        mark_dirty!
+      end
+      true
     end
 
     # TextEditor cursor columns are character indexes while PieceTreeBuffer


### PR DESCRIPTION
Adds editor primitives needed for safe external-file conflict handling in Adamantine.

Changes:
- reload disk content as the saved baseline while preserving the previous piece-tree root as one undo step
- accept identical content as saved without creating redundant undo or LSP changes
- cap external reload history to the immediately previous root
- split checked save into pre-rename and post-rename validation so clean state and save callbacks are published only after both checks pass

Verification:
- focused editor suite: 36 examples, 0 failures
- full suite: 652 examples with four pre-existing mouse-order failures reproduced on the exact main baseline
- formatting and diff checks pass

Safety boundary:
The validators narrow external-writer races but do not claim portable filesystem compare-and-swap semantics.